### PR TITLE
Update install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,7 @@
 You can easily install archivy with `pip`.
 
 
-- Make sure your system has Python and pip installed.
+- Make sure your system has Python, pip and Pandoc installed.
 - Install the python package with `pip install archivy`
 - There you go! You should be able to start the app by running `archivy run` in your terminal.
 


### PR DESCRIPTION
I attempted to install from PIP on a fresh Ubuntu 20.04 install. It failed because of a Pandoc dependency. Updating the doc to reflect this. 