### PR TITLE
DarkTheme: correction for the contrast of the Edit Profile button

### DIFF
--- a/archivy/static/main.css
+++ b/archivy/static/main.css
@@ -152,6 +152,11 @@ body form {
 	background: #ed6663;
 }
 
+.dark-theme img#pfp {
+    -webkit-filter: invert(100%);
+    filter: invert(100%);
+}
+
 #pfp {
 	margin: 15px;
 }


### PR DESCRIPTION
Added a rule to invert the colors of the edit profile button at the home page, as means of improving contrast in the Dark Theme.

(The edit profile button is an SVG located at the left top corner of the screen, currently acts as a button)

_Before:_

![chrome_2020-11-21_19-02-17](https://user-images.githubusercontent.com/7027160/99888503-2112de80-2c2c-11eb-84fb-8a881b04ac2c.png)

_After:_

![image](https://user-images.githubusercontent.com/7027160/99888515-32f48180-2c2c-11eb-80f9-2f8ec57cc98c.png)
