### PR TITLE
Changes to the watcher and how archivy converts unformatted files

### DIFF
--- a/archivy/__init__.py
+++ b/archivy/__init__.py
@@ -32,7 +32,7 @@ if app.config["SEARCH_CONF"]["enabled"]:
             es.indices.create(
                 index=app.config["SEARCH_CONF"]["index_name"],
                 body=app.config["SEARCH_CONF"]["search_conf"])
-        except elasticsearch.ElasticsearchException:
+        except elasticsearch.exceptions.RequestError:
             app.logger.info("Elasticsearch index already created")
 
 

--- a/archivy/__init__.py
+++ b/archivy/__init__.py
@@ -25,13 +25,13 @@ app.config.from_object(config)
 
 (Path(app.config["USER_DIR"]) / "data").mkdir(parents=True, exist_ok=True)
 
-if app.config["ELASTICSEARCH_CONF"]["enabled"]:
+if app.config["SEARCH_CONF"]["enabled"]:
     with app.app_context():
         es = helpers.get_elastic_client()
         try:
             es.indices.create(
-                index=app.config["ELASTICSEARCH_CONF"]["index_name"],
-                body=app.config["ELASTICSEARCH_CONF"]["search_conf"])
+                index=app.config["SEARCH_CONF"]["index_name"],
+                body=app.config["SEARCH_CONF"]["search_conf"])
         except elasticsearch.ElasticsearchException:
             app.logger.info("Elasticsearch index already created")
 

--- a/archivy/api.py
+++ b/archivy/api.py
@@ -195,5 +195,5 @@ def search_elastic():
     - **query**
     """
     query = request.args.get("query")
-    search_results = query_index(current_app.config["SEARCH_CONF"]["index_name"], query)
+    search_results = query_index(query)
     return jsonify(search_results)

--- a/archivy/api.py
+++ b/archivy/api.py
@@ -195,5 +195,5 @@ def search_elastic():
     - **query**
     """
     query = request.args.get("query")
-    search_results = query_index(current_app.config["ELASTICSEARCH_CONF"]["index_name"], query)
+    search_results = query_index(current_app.config["SEARCH_CONF"]["index_name"], query)
     return jsonify(search_results)

--- a/archivy/check_changes.py
+++ b/archivy/check_changes.py
@@ -19,46 +19,7 @@ class ModifHandler(FileSystemEventHandler):
         self.app.logger.info("Running watcher")
         self.ELASTIC = app.config["SEARCH_CONF"]["enabled"]
         self.data_dir = os.path.join(app.config["USER_DIR"], "data" + SEP)
-        self.last_formatted = ""
-        self.time_formatted = time.time()
 
-    def is_unformatted(self, filename):
-        return (not re.match(DATAOBJ_REGEX, filename)
-                and not filename.startswith(".")
-                and filename.endswith(".md"))
-
-    def format_file(self, filepath):
-        # weird buggy errors with watchdog where event is triggered twice
-        if filepath == self.last_formatted and time.time() - self.time_formatted <= 40:
-            return
-
-        try:
-            new_file = open(filepath, "r")
-            file_contents = new_file.read()
-            new_file.close()
-        except FileNotFoundError:
-            return
-
-        # extract name of file
-        split_path = filepath.replace(self.data_dir, "").split(SEP)
-        file_title = split_path[-1].split(".")[0]
-        directory = "/".join(split_path[0:-1])
-        note_dataobj = {
-                "title": file_title,
-                "content": file_contents,
-                "type": "note",
-                "path": directory
-            }
-
-        dataobj = models.DataObj(**note_dataobj)
-        dataobj.insert()
-
-        self.last_formatted = filepath
-        self.time_formatted = time.time()
-        try:
-            os.remove(filepath)
-        except FileNotFoundError:
-            return
 
     def on_modified(self, event):
         with self.app.app_context():
@@ -71,8 +32,7 @@ class ModifHandler(FileSystemEventHandler):
                     search.add_to_index(
                             self.app.config["SEARCH_CONF"]["index_name"],
                             dataobj)
-            elif self.is_unformatted(filename):
-                self.format_file(event.src_path)
+
 
     def on_deleted(self, event):
         with self.app.app_context():
@@ -82,13 +42,6 @@ class ModifHandler(FileSystemEventHandler):
                 id = event.src_path.split(SEP)[-1].split("-")[0]
                 search.remove_from_index(self.app.config["SEARCH_CONF"]["index_name"], id)
                 self.app.logger.info(f"{event.src_path} has been removed")
-
-    def on_created(self, event):
-        with self.app.app_context():
-            filename = event.src_path.split(SEP)[-1]
-            # check file is not formatted and is md file and is not temp file
-            if self.is_unformatted(filename):
-                self.format_file(event.src_path)
 
 
 class Watcher(Thread):

--- a/archivy/check_changes.py
+++ b/archivy/check_changes.py
@@ -29,16 +29,16 @@ class ModifHandler(FileSystemEventHandler):
                     dataobj = models.DataObj.from_md(f.read())
                 if dataobj.validate():
                     search.add_to_index(
-                            self.app.config["SEARCH_CONF"]["index_name"],
                             dataobj)
 
     def on_deleted(self, event):
         with self.app.app_context():
             filename = event.src_path.split(SEP)[-1]
+            print(filename)
             if (re.match(DATAOBJ_REGEX, filename)
                     and self.ELASTIC):
                 id = event.src_path.split(SEP)[-1].split("-")[0]
-                search.remove_from_index(self.app.config["SEARCH_CONF"]["index_name"], id)
+                search.remove_from_index(id)
                 self.app.logger.info(f"{event.src_path} has been removed")
 
 

--- a/archivy/check_changes.py
+++ b/archivy/check_changes.py
@@ -17,7 +17,7 @@ class ModifHandler(FileSystemEventHandler):
     def __init__(self, app: flask.Flask):
         self.app = app
         self.app.logger.info("Running watcher")
-        self.ELASTIC = app.config["ELASTICSEARCH_CONF"]["enabled"]
+        self.ELASTIC = app.config["SEARCH_CONF"]["enabled"]
         self.data_dir = os.path.join(app.config["USER_DIR"], "data" + SEP)
         self.last_formatted = ""
         self.time_formatted = time.time()
@@ -69,7 +69,7 @@ class ModifHandler(FileSystemEventHandler):
                     dataobj = models.DataObj.from_md(f.read())
                 if dataobj.validate():
                     search.add_to_index(
-                            self.app.config["ELASTICSEARCH_CONF"]["index_name"],
+                            self.app.config["SEARCH_CONF"]["index_name"],
                             dataobj)
             elif self.is_unformatted(filename):
                 self.format_file(event.src_path)
@@ -80,7 +80,7 @@ class ModifHandler(FileSystemEventHandler):
             if (re.match(DATAOBJ_REGEX, filename)
                     and self.ELASTIC):
                 id = event.src_path.split(SEP)[-1].split("-")[0]
-                search.remove_from_index(self.app.config["ELASTICSEARCH_CONF"]["index_name"], id)
+                search.remove_from_index(self.app.config["SEARCH_CONF"]["index_name"], id)
                 self.app.logger.info(f"{event.src_path} has been removed")
 
     def on_created(self, event):

--- a/archivy/check_changes.py
+++ b/archivy/check_changes.py
@@ -34,7 +34,6 @@ class ModifHandler(FileSystemEventHandler):
     def on_deleted(self, event):
         with self.app.app_context():
             filename = event.src_path.split(SEP)[-1]
-            print(filename)
             if (re.match(DATAOBJ_REGEX, filename)
                     and self.ELASTIC):
                 id = event.src_path.split(SEP)[-1].split("-")[0]

--- a/archivy/check_changes.py
+++ b/archivy/check_changes.py
@@ -20,7 +20,6 @@ class ModifHandler(FileSystemEventHandler):
         self.ELASTIC = app.config["SEARCH_CONF"]["enabled"]
         self.data_dir = os.path.join(app.config["USER_DIR"], "data" + SEP)
 
-
     def on_modified(self, event):
         with self.app.app_context():
             filename = event.src_path.split(SEP)[-1]
@@ -32,7 +31,6 @@ class ModifHandler(FileSystemEventHandler):
                     search.add_to_index(
                             self.app.config["SEARCH_CONF"]["index_name"],
                             dataobj)
-
 
     def on_deleted(self, event):
         with self.app.app_context():

--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -9,7 +9,7 @@ from archivy import app
 from archivy.check_changes import Watcher
 from archivy.config import Config
 from archivy.click_web import create_click_web_app
-from archivy.data import open_file
+from archivy.data import open_file, reformat_file
 from archivy.helpers import load_config, write_config
 from archivy.models import User
 
@@ -112,3 +112,10 @@ def create_admin(username, password):
         else:
             click.echo("User with given username already exists.")
             return False
+
+
+@cli.command(short_help="Format normal markdown files for archivy.")
+@click.argument("filenames", type=click.Path(exists=True), nargs=-1)
+def format(filenames):
+    for path in filenames:
+        reformat_file(path)

--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -9,7 +9,7 @@ from archivy import app
 from archivy.check_changes import Watcher
 from archivy.config import Config
 from archivy.click_web import create_click_web_app
-from archivy.data import open_file, reformat_file
+from archivy.data import open_file, format_file, unformat_file
 from archivy.helpers import load_config, write_config
 from archivy.models import User
 
@@ -118,4 +118,11 @@ def create_admin(username, password):
 @click.argument("filenames", type=click.Path(exists=True), nargs=-1)
 def format(filenames):
     for path in filenames:
-        reformat_file(path)
+        format_file(path)
+
+@cli.command(short_help="Convert archivy-formatted files back to normal markdown.")
+@click.argument("filenames", type=click.Path(exists=True), nargs=-1)
+@click.argument("output_dir", type=click.Path(exists=True, file_okay=False))
+def unformat(filenames, output_dir):
+    for path in filenames:
+        unformat_file(path, output_dir)

--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -1,4 +1,5 @@
-import os
+from pathlib import Path
+from os import environ
 from pkg_resources import iter_entry_points
 
 import click
@@ -9,9 +10,9 @@ from archivy import app
 from archivy.check_changes import Watcher
 from archivy.config import Config
 from archivy.click_web import create_click_web_app
-from archivy.data import open_file, format_file, unformat_file
+from archivy.data import open_file, format_file, unformat_file, get_items
 from archivy.helpers import load_config, write_config
-from archivy.models import User
+from archivy.models import User, DataObj
 
 
 def create_app():
@@ -45,7 +46,7 @@ def init(ctx):
     data_dir = click.prompt("Enter the full path of the "
                             "directory where you'd like us to store data.",
                             type=str,
-                            default=os.getcwd())
+                            default=str(Path(".").resolve()))
 
     es_enabled = click.confirm("Would you like to enable Elasticsearch? For this to work "
                                "when you run archivy, you must have ES installed."
@@ -69,16 +70,16 @@ def init(ctx):
     app.config["USER_DIR"] = data_dir
 
     # create data dir
-    os.makedirs(os.path.join(data_dir, "data"), exist_ok=True)
+    (Path(data_dir) / "data").mkdir(exist_ok=True)
 
     write_config(vars(config))
     click.echo("Config successfully created at "
-               + os.path.join(app.config['INTERNAL_DIR'], 'config.yml'))
+               + str((Path(app.config['INTERNAL_DIR']) / 'config.yml').resolve()))
 
 
 @cli.command("config", short_help="Open archivy config.")
 def config():
-    open_file(os.path.join(app.config["INTERNAL_DIR"], "config.yml"))
+    open_file(str(Path(app.config["INTERNAL_DIR"]) / "config.yml"))
 
 
 @cli.command("run", short_help="Runs archivy web application")
@@ -88,11 +89,11 @@ def run():
     if app.config["SEARCH_CONF"]["enable_watcher"]:
         watcher = Watcher(app)
         watcher.start()
-    os.environ["FLASK_RUN_FROM_CLI"] = "false"
+    environ["FLASK_RUN_FROM_CLI"] = "false"
     app_with_cli = create_click_web_app(click, cli, app)
     app_with_cli.run(host=app.config["HOST"], port=app.config["PORT"])
-    click.echo("Stopping archivy watcher")
     if app.config["SEARCH_CONF"]["enable_watcher"]:
+        click.echo("Stopping archivy watcher")
         watcher.stop()
         watcher.join()
 
@@ -127,3 +128,22 @@ def format(filenames):
 def unformat(filenames, output_dir):
     for path in filenames:
         unformat_file(path, output_dir)
+
+
+@cli.command(short_help="Sync content to Elasticsearch")
+def index():
+    data_dir = Path(app.config["USER_DIR"]) / "data"
+
+    if not app.config["SEARCH_CONF"]["enabled"]:
+        click.echo("Search must be enabled for this command.")
+        return
+
+    for filename in data_dir.rglob("*.md"):
+        cur_file = open(filename)
+        dataobj = DataObj.from_md(cur_file.read())
+        cur_file.close()
+
+        if dataobj.index():
+            click.echo(f"Indexed {dataobj.title}...")
+        else:
+            click.echo(f"Failed to index {dataobj.title}")

--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -51,9 +51,9 @@ def init(ctx):
                                "when you run archivy, you must have ES installed."
                                "See https://archivy.github.io/setup-search/ for more info.")
     if es_enabled:
-        config.ELASTICSEARCH_CONF["enabled"] = 1
+        config.SEARCH_CONF["enabled"] = 1
     else:
-        delattr(config, "ELASTICSEARCH_CONF")
+        delattr(config, "SEARCH_CONF")
 
     create_new_user = click.confirm("Would you like to create a new admin user?")
     if create_new_user:
@@ -85,14 +85,16 @@ def config():
 def run():
     click.echo('Running archivy...')
     load_dotenv()
-    watcher = Watcher(app)
-    watcher.start()
+    if app.config["SEARCH_CONF"]["enable_watcher"]:
+        watcher = Watcher(app)
+        watcher.start()
     os.environ["FLASK_RUN_FROM_CLI"] = "false"
     app_with_cli = create_click_web_app(click, cli, app)
     app_with_cli.run(host=app.config["HOST"], port=app.config["PORT"])
     click.echo("Stopping archivy watcher")
-    watcher.stop()
-    watcher.join()
+    if app.config["SEARCH_CONF"]["enable_watcher"]:
+        watcher.stop()
+        watcher.join()
 
 
 @cli.command(short_help="Creates a new admin user")

--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -10,7 +10,7 @@ from archivy import app
 from archivy.check_changes import Watcher
 from archivy.config import Config
 from archivy.click_web import create_click_web_app
-from archivy.data import open_file, format_file, unformat_file, get_items
+from archivy.data import open_file, format_file, unformat_file
 from archivy.helpers import load_config, write_config
 from archivy.models import User, DataObj
 

--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -120,6 +120,7 @@ def format(filenames):
     for path in filenames:
         format_file(path)
 
+
 @cli.command(short_help="Convert archivy-formatted files back to normal markdown.")
 @click.argument("filenames", type=click.Path(exists=True), nargs=-1)
 @click.argument("output_dir", type=click.Path(exists=True, file_okay=False))

--- a/archivy/config.py
+++ b/archivy/config.py
@@ -15,7 +15,8 @@ class Config(object):
 
         self.PANDOC_HIGHLIGHT_THEME = "pygments"
 
-        self.ELASTICSEARCH_CONF = {
+        self.SEARCH_CONF = {
+                "enable_watcher": True,
                 "enabled": 0,
                 "url": "http://localhost:9200",
                 "index_name": "dataobj",
@@ -57,8 +58,8 @@ class Config(object):
     def override(self, user_conf: dict):
         for k, v in user_conf.items():
             # handle ES options, don't override entire dict if one key is passed
-            if k == "ELASTICSEARCH_CONF":
+            if k == "SEARCH_CONF":
                 for subkey, subval in v.items():
-                    self.ELASTICSEARCH_CONF[subkey] = subval
+                    self.SEARCH_CONF[subkey] = subval
             else:
                 setattr(self, k, v)

--- a/archivy/data.py
+++ b/archivy/data.py
@@ -9,7 +9,6 @@ from flask import current_app
 from werkzeug.utils import secure_filename
 
 
-
 # FIXME: ugly hack to make sure the app path is evaluated at the right time
 def get_data_dir():
     """Returns the directory where dataobjs are stored"""
@@ -180,6 +179,7 @@ def delete_dir(name):
     except FileNotFoundError:
         return False
 
+
 def format_file(path: str):
     """
     Converts normal md of file at `path` to formatted archivy markdown file, with yaml front matter
@@ -217,7 +217,8 @@ def format_file(path: str):
         dataobj.insert()
 
         path.unlink()
-        current_app.logger.info(f"Formatted and moved {str(datapath / path.name)} to {dataobj.fullpath}")
+        current_app.logger.info(
+                f"Formatted and moved {str(datapath / path.name)} to {dataobj.fullpath}")
 
 
 def unformat_file(path: str, out_dir: str):
@@ -226,7 +227,6 @@ def unformat_file(path: str, out_dir: str):
     and a filename of format "{id}-{old_filename}.md"
     """
 
-    from archivy.models import DataObj
     data_dir = get_data_dir()
     path = Path(path)
     out_dir = Path(out_dir)

--- a/archivy/data.py
+++ b/archivy/data.py
@@ -8,6 +8,8 @@ import frontmatter
 from flask import current_app
 from werkzeug.utils import secure_filename
 
+from archivy.search import remove_from_index
+
 
 # FIXME: ugly hack to make sure the app path is evaluated at the right time
 def get_data_dir():
@@ -108,6 +110,7 @@ def get_item(dataobj_id):
 def delete_item(dataobj_id):
     """Delete dataobj of given id"""
     file = get_by_id(dataobj_id)
+    remove_from_index(dataobj_id)
     if file:
         Path(file).unlink()
 

--- a/archivy/helpers.py
+++ b/archivy/helpers.py
@@ -53,6 +53,8 @@ def set_max_id(val):
     db.update(operations.set("val", val), Query().name == "max_id")
 
 
+
+
 def get_elastic_client():
     """Returns the elasticsearch client you can use to search and insert / delete data"""
     if not current_app.config["SEARCH_CONF"]["enabled"]:

--- a/archivy/helpers.py
+++ b/archivy/helpers.py
@@ -55,16 +55,16 @@ def set_max_id(val):
 
 def get_elastic_client():
     """Returns the elasticsearch client you can use to search and insert / delete data"""
-    if not current_app.config["ELASTICSEARCH_CONF"]["enabled"]:
+    if not current_app.config["SEARCH_CONF"]["enabled"]:
         return None
 
-    es = Elasticsearch(current_app.config["ELASTICSEARCH_CONF"]["url"])
+    es = Elasticsearch(current_app.config["SEARCH_CONF"]["url"])
     try:
         health = es.cluster.health()
     except elasticsearch.exceptions.ConnectionError:
         current_app.logger.error(
             "Elasticsearch does not seem to be running on "
-            f"{current_app.config['ELASTICSEARCH_CONF']['url']}. Please start "
+            f"{current_app.config['SEARCH_CONF']['url']}. Please start "
             "it, for example with: sudo service elasticsearch restart"
         )
         current_app.logger.error(

--- a/archivy/helpers.py
+++ b/archivy/helpers.py
@@ -53,8 +53,6 @@ def set_max_id(val):
     db.update(operations.set("val", val), Query().name == "max_id")
 
 
-
-
 def get_elastic_client():
     """Returns the elasticsearch client you can use to search and insert / delete data"""
     if not current_app.config["SEARCH_CONF"]["enabled"]:

--- a/archivy/models.py
+++ b/archivy/models.py
@@ -194,9 +194,13 @@ class DataObj:
                                 path=self.path,
                                 )
 
-            add_to_index(current_app.config["SEARCH_CONF"]["index_name"], self)
+            self.index()
             return self.id
         return False
+
+    def index(self):
+        return add_to_index(self)
+
 
     @classmethod
     def from_md(cls, md_content: str):

--- a/archivy/models.py
+++ b/archivy/models.py
@@ -8,7 +8,7 @@ import validators
 from attr import attrs, attrib
 from attr.validators import instance_of, optional
 from bs4 import BeautifulSoup
-from flask import current_app, flash
+from flask import flash
 from flask_login import UserMixin
 from html2text import html2text
 from tinydb import Query
@@ -200,7 +200,6 @@ class DataObj:
 
     def index(self):
         return add_to_index(self)
-
 
     @classmethod
     def from_md(cls, md_content: str):

--- a/archivy/models.py
+++ b/archivy/models.py
@@ -194,7 +194,7 @@ class DataObj:
                                 path=self.path,
                                 )
 
-            add_to_index(current_app.config["ELASTICSEARCH_CONF"]["index_name"], self)
+            add_to_index(current_app.config["SEARCH_CONF"]["index_name"], self)
             return self.id
         return False
 

--- a/archivy/routes.py
+++ b/archivy/routes.py
@@ -37,7 +37,7 @@ def index():
     return render_template(
             "home.html",
             title="Home",
-            search_enabled=app.config["ELASTICSEARCH_CONF"]["enabled"],
+            search_enabled=app.config["SEARCH_CONF"]["enabled"],
             )
 
 

--- a/archivy/search.py
+++ b/archivy/search.py
@@ -46,12 +46,11 @@ def query_index(query):
                 }
             },
             "highlight": {
+                "fragment_size": 0,
                 "fields": {
                     "content": {
                         "pre_tags": "==",
                         "post_tags": "==",
-                        "boundary_max_scan": 200,
-                        "fragment_size": 0
                     }
                 }
             }

--- a/archivy/search.py
+++ b/archivy/search.py
@@ -1,7 +1,9 @@
+from flask import current_app
+
 from archivy.helpers import get_elastic_client
 
 
-def add_to_index(index, model):
+def add_to_index(model):
     """
     Adds dataobj to given index. If object of given id already exists, it will be updated.
 
@@ -16,24 +18,25 @@ def add_to_index(index, model):
     payload = {}
     for field in model.__searchable__:
         payload[field] = getattr(model, field)
-    es.index(index=index, id=model.id, body=payload)
+    es.index(index=current_app.config["SEARCH_CONF"]["index_name"], id=model.id, body=payload)
+    return True
 
 
-def remove_from_index(index, dataobj_id):
+def remove_from_index(dataobj_id):
     """Removes object of given id"""
     es = get_elastic_client()
     if not es:
         return
-    es.delete(index=index, id=dataobj_id)
+    es.delete(index=current_app.config["SEARCH_CONF"]["index_name"], id=dataobj_id)
 
 
-def query_index(index, query):
+def query_index(query):
     """Returns search results for your given query"""
     es = get_elastic_client()
     if not es:
         return []
     search = es.search(
-        index=index,
+        index=current_app.config["SEARCH_CONF"]["index_name"],
         body={
             "query": {
                 "multi_match": {

--- a/archivy/static/main.css
+++ b/archivy/static/main.css
@@ -186,6 +186,10 @@ mark {
 	content: "LaTeX"
 }
 
+#searchBar {
+	border: 1px solid #dfe1e5; border-radius: 5px
+}
+
 
 @media only screen and (max-width: 500px) {
   .content {

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,10 +17,10 @@ Here's an overview of the different values you can set and modify.
 
 ### Elasticsearch
 
-All of these are children of the `ELASTICSEARCH_CONF` object, like this in the yaml:
+All of these are children of the `SEARCH_CONF` object, like this in the yaml:
 
 ```yaml
-ELASTICSEARCH_CONF:
+SEARCH_CONF:
   enabled:
   url:
   # ...
@@ -31,6 +31,7 @@ This part will not be configured by default unless you specify you wish to integ
 | Variable                | Default                        | Description                           |
 |-------------------------|--------------------------------|---------------------------------------|
 | `enabled`               | 1                              |                                       |
+| `enable_watcher`        | 1                              | Whether or not to run the watcher that auto-syncs changes to dataobjs to Elasticsearch. Otherwise you can handle syncing yourself through `archivy search-index` |
 | `url`                   | http://localhost:9200          | Url to the elasticsearch server       |
 | `search_conf`           | Long dict of ES config options | Configuration of Elasticsearch [analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html), [mappings](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html) and general settings. |
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -53,7 +53,7 @@ setup(
 
 Let's walk through what this is doing. We are setting up our package and we define a few characteristics of the package. We specify some metadata you can adapt to your own package. We then load our package by using the `find_packages` function. The `entry_points` part is the most important. The `[archivy.plugins]` tells archivy that this package will extend our CLI and then we define the command we want to add. In our case, people will call the extension using `archivy pocket`. We will actually be creating a group so that people will call subcommands like this: `archivy pocket <subcommand>`. You can do things either way.
 
-Create a `README.md` file that you can keep empty for now but should haCve information on your project.
+Create a `README.md` file that you can keep empty for now but should store information on your project.
 
 ## Step 3: Writing the core code of our plugin
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -45,11 +45,7 @@ Check out the [helper methods](search.md) archivy exposes for ES.
 
 Since the DataObjs are stored on the filesystem, archivy runs a daemon to check for changes in the files.
 
-
-What it does:
-
-- If you have elasticsearch enabled, whenever you edit a file, it will sync the changes to ES.
-- Say you have a large amount of markdown files, that are obviously not formatted to be used by archivy. Moving them into your DataObj dir will cause the daemon to automatically format them so they conform to the archivy format and can be used.
+It has a simple function: if you have elasticsearch enabled, whenever you edit a file, it will sync the changes to ES.
 
 
 ## Auth

--- a/docs/setup-search.md
+++ b/docs/setup-search.md
@@ -14,7 +14,7 @@ Then, when you run `archivy init` simply specify you have enabled ES to integrat
 
 You will now have full-text search on your knowledge base!
 
-Whenever you edit an item through the files, it is better to have archivy running that way your changes will be synced to Elasticsearch.
+Whenever you edit an item locally, it is better to have archivy running that way your changes will be automatically synced to Elasticsearch.
 
 
 Elasticsearch can be a hefty dependency, so if you have any ideas for something more light-weight that could be used as an alternative, please share on [this thread](https://github.com/archivy/archivy/issues/13).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,7 @@ Options:
 Commands:
   config        Open archivy config.
   create-admin  Creates a new admin user
+  format        Format normal markdown files for archivy.
   init          Initialise your archivy application
   run           Runs archivy web application
   shell         Run a shell in the app context.
@@ -18,6 +19,8 @@ Commands:
 Make sure you've configured Archivy by running `archivy init`, as outlined in [install](install.md).
 
 If you'd like to add users, you can simply create new admin users with the `create-admin` command. Only give credentials to trusted people.
+
+If you have normal md files you'd like to migrate to archivy, move your files into your archivy data directory and then run `archivy format <filenames>` to make them conform to [archivy's formatting](/reference/architecture/#data-storage).
 
 The `config` command allows you to play around with [configuration](config.md) and use `shell` if you'd like to play around with the archivy python API.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,13 +14,14 @@ Commands:
   init          Initialise your archivy application
   run           Runs archivy web application
   shell         Run a shell in the app context.
+  unformat      Convert archivy-formatted files back to normal markdown.
 ```
 
 Make sure you've configured Archivy by running `archivy init`, as outlined in [install](install.md).
 
 If you'd like to add users, you can simply create new admin users with the `create-admin` command. Only give credentials to trusted people.
 
-If you have normal md files you'd like to migrate to archivy, move your files into your archivy data directory and then run `archivy format <filenames>` to make them conform to [archivy's formatting](/reference/architecture/#data-storage).
+If you have normal md files you'd like to migrate to archivy, move your files into your archivy data directory and then run `archivy format <filenames>` to make them conform to [archivy's formatting](/reference/architecture/#data-storage). Run `archivy unformat` to convert the other way around.
 
 The `config` command allows you to play around with [configuration](config.md) and use `shell` if you'd like to play around with the archivy python API.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,6 +11,7 @@ Commands:
   config        Open archivy config.
   create-admin  Creates a new admin user
   format        Format normal markdown files for archivy.
+  index         Sync content to Elasticsearch
   init          Initialise your archivy application
   run           Runs archivy web application
   shell         Run a shell in the app context.
@@ -22,6 +23,8 @@ Make sure you've configured Archivy by running `archivy init`, as outlined in [i
 If you'd like to add users, you can simply create new admin users with the `create-admin` command. Only give credentials to trusted people.
 
 If you have normal md files you'd like to migrate to archivy, move your files into your archivy data directory and then run `archivy format <filenames>` to make them conform to [archivy's formatting](/reference/architecture/#data-storage). Run `archivy unformat` to convert the other way around.
+
+You can sync changes to files to the Elasticsearch index by running `archivy index` or by simply running archivy when you edit (and not disabling the [watcher](/reference/architecture#daemon).
 
 The `config` command allows you to play around with [configuration](config.md) and use `shell` if you'd like to play around with the archivy python API.
 


### PR DESCRIPTION
This PR introduces several changes:

- Renames `ELASTICSEARCH_CONF` to `SEARCH_CONF` for future integration with other search engines #13
- Add `enable_watcher` key to ^ above config object for whether or not to run the watcher that syncs file changes to ES.
- Watcher used to check when there was a new file in the data directory, and if unformatted, would convert it to archivy format. This no longer exists, and instead a `format` and `unformat` command have been added to the cli.
- Addition of `index` command to index all files for ES.
