### PR TITLE
fix: 'archivy init' does not purge old configuration before interactive init

### DIFF
--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -7,7 +7,7 @@ from click_plugins import with_plugins
 from flask.cli import FlaskGroup, load_dotenv, shell_command
 
 from archivy import app
-from archivy.config import Config
+from archivy.config import Config, VERSION
 from archivy.click_web import create_click_web_app
 from archivy.data import open_file, format_file, unformat_file
 from archivy.helpers import load_config, write_config
@@ -37,6 +37,9 @@ def init(ctx):
                       "Otherwise run `archivy config`", abort=True)
     except FileNotFoundError:
         pass
+
+    # remove the old configuration, and add version to it
+    write_config({"version": VERSION})
 
     config = Config()
     delattr(config, "SECRET_KEY")

--- a/archivy/config.py
+++ b/archivy/config.py
@@ -1,9 +1,14 @@
 import os
 import appdirs
 
+# version of archivy configuration file
+VERSION = 1
+
 
 class Config(object):
     """Configuration object for the application"""
+
+    VERSION = VERSION
 
     def __init__(self):
         self.SECRET_KEY = os.urandom(32)


### PR DESCRIPTION
archivy does not reset the configuration before creating the new user.
This is because archivy calls click.create_admin before resetting the configuration.
It is also recommended to purge the configuration, (and not replace existing conf), to
remove old entries

along with this patch, a new value, VERSION would be added to the configuration
which would be useful in future to migrate old configuration to new configuration tree.