### PR TITLE
Use better server for running archivy in production

### DIFF
--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -5,7 +5,7 @@ from pkg_resources import iter_entry_points
 import click
 from click_plugins import with_plugins
 from flask.cli import FlaskGroup, load_dotenv, shell_command
-import gunicorn.app.base
+from gunicorn.app.base import BaseApplication
 
 from archivy import app
 from archivy.config import Config
@@ -27,7 +27,6 @@ def cli():
 
 # add built in commands:
 cli.add_command(shell_command)
-
 
 
 @cli.command("init", short_help="Initialise your archivy application")
@@ -103,7 +102,7 @@ def run():
     environ["FLASK_RUN_FROM_CLI"] = "false"
     app_with_cli = create_click_web_app(click, cli, app)
 
-    class GunicornApp(gunicorn.app.base.BaseApplication):
+    class GunicornApp(BaseApplication):
         """Application used to run the gunicorn server"""
         def __init__(self, app, options=None):
             self.options = options or {}
@@ -124,8 +123,6 @@ def run():
     }
 
     GunicornApp(app_with_cli, options).run()
-
-        
 
 
 @cli.command(short_help="Creates a new admin user")
@@ -177,5 +174,3 @@ def index():
             click.echo(f"Indexed {dataobj.title}...")
         else:
             click.echo(f"Failed to index {dataobj.title}")
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,4 @@ flask-login == 0.5.0
 click_plugins
 html2text
 flask_compress
+gunicorn


### PR DESCRIPTION
Fixes #170 by using [gunicorn](https://gunicorn.org]

Introduces an efficient, more suited webserver for the application.