### PR TITLE
fix: expose __main__ on archivy.cli

### DIFF
--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -153,3 +153,7 @@ def index():
             click.echo(f"Indexed {dataobj.title}...")
         else:
             click.echo(f"Failed to index {dataobj.title}")
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Now its possible to run archivy directly from source
without installing archivy first by using

$ python3 -m archivy.cli --help

This can help test multiple versions of archivy without
creating multiple virtualenv's.