### PR TITLE
Move to the 'black' code style.

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,4 @@
-name: Flake8 Code Quality
+name: Black Code Quality
 
 on: 
   push:
@@ -6,14 +6,14 @@ on:
       - 'master'
     paths:
       - 'archivy/**'
-      - '.github/workflows/flake.yml'
+      - '.github/workflows/black.yml'
       - 'conftest.py'
       - 'tests/**'
 
   pull_request:
     paths:
       - 'archivy/**'
-      - '.github/workflows/flake.yml'
+      - '.github/workflows/black.yml'
       - 'conftest.py'
       - 'tests/**'
 
@@ -32,9 +32,8 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel
         pip install -r requirements.txt
-    - name: Lint with flake8
+    - name: Lint with black
       run: |
-        pip install flake8
-        flake8 --max-line-length 99 archivy
-        
+        pip install black
+        black --check .
 

--- a/archivy/__init__.py
+++ b/archivy/__init__.py
@@ -31,7 +31,8 @@ if app.config["SEARCH_CONF"]["enabled"]:
         try:
             es.indices.create(
                 index=app.config["SEARCH_CONF"]["index_name"],
-                body=app.config["SEARCH_CONF"]["search_conf"])
+                body=app.config["SEARCH_CONF"]["search_conf"],
+            )
         except elasticsearch.exceptions.RequestError:
             app.logger.info("Elasticsearch index already created")
 
@@ -40,7 +41,7 @@ if app.config["SEARCH_CONF"]["enabled"]:
 login_manager = LoginManager()
 login_manager.login_view = "login"
 login_manager.init_app(app)
-app.register_blueprint(api_bp, url_prefix='/api')
+app.register_blueprint(api_bp, url_prefix="/api")
 
 # compress files
 Compress(app)
@@ -58,11 +59,12 @@ def load_user(user_id):
 app.jinja_options["extensions"].append("jinja2.ext.do")
 
 
-@app.template_filter('pluralize')
-def pluralize(number, singular='', plural='s'):
+@app.template_filter("pluralize")
+def pluralize(number, singular="", plural="s"):
     if number == 1:
         return singular
     else:
         return plural
+
 
 from archivy import routes  # noqa:

--- a/archivy/api.py
+++ b/archivy/api.py
@@ -9,7 +9,7 @@ from archivy.models import DataObj, User
 from archivy.helpers import get_db
 
 
-api_bp = Blueprint('api', __name__)
+api_bp = Blueprint("api", __name__)
 
 
 @api_bp.route("/login", methods=["POST"])
@@ -21,10 +21,9 @@ def login():
     """
     db = get_db()
     user = db.search(Query().username == request.authorization["username"])
-    if (user and
-            check_password_hash(
-                user[0]["hashed_password"],
-                request.authorization["password"])):
+    if user and check_password_hash(
+        user[0]["hashed_password"], request.authorization["password"]
+    ):
         # user is verified so we can log him in from the db
         user = User.from_db(user[0])
         login_user(user, remember=True)
@@ -46,8 +45,8 @@ def create_bookmark():
     """
     json_data = request.get_json()
     bookmark = DataObj(
-        url=json_data['url'],
-        tags=json_data.get('tags'),
+        url=json_data["url"],
+        tags=json_data.get("tags"),
         path=json_data.get("path", ""),
         type="bookmark",
     )
@@ -79,7 +78,7 @@ def create_note():
         content=json_data["content"],
         tags=json_data.get("tags"),
         path=json_data.get("path", ""),
-        type="note"
+        type="note",
     )
 
     note_id = note.insert()
@@ -93,12 +92,16 @@ def get_dataobj(dataobj_id):
     """Returns dataobj of given id"""
     dataobj = data.get_item(dataobj_id)
 
-    return jsonify(
-        dataobj_id=dataobj_id,
-        title=dataobj["title"],
-        content=dataobj.content,
-        md_path=dataobj["fullpath"],
-    ) if dataobj else Response(status=404)
+    return (
+        jsonify(
+            dataobj_id=dataobj_id,
+            title=dataobj["title"],
+            content=dataobj.content,
+            md_path=dataobj["fullpath"],
+        )
+        if dataobj
+        else Response(status=404)
+    )
 
 
 @api_bp.route("/dataobjs/<int:dataobj_id>", methods=["DELETE"])

--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -18,7 +18,7 @@ def create_app():
     return app
 
 
-@with_plugins(iter_entry_points('archivy.plugins'))
+@with_plugins(iter_entry_points("archivy.plugins"))
 @click.group(cls=FlaskGroup, create_app=create_app)
 def cli():
     pass
@@ -33,8 +33,11 @@ cli.add_command(shell_command)
 def init(ctx):
     try:
         load_config()
-        click.confirm("Config already found. Do you wish to reset it? "
-                      "Otherwise run `archivy config`", abort=True)
+        click.confirm(
+            "Config already found. Do you wish to reset it? "
+            "Otherwise run `archivy config`",
+            abort=True,
+        )
     except FileNotFoundError:
         pass
 
@@ -42,14 +45,17 @@ def init(ctx):
     delattr(config, "SECRET_KEY")
 
     click.echo("This is the archivy installation initialization wizard.")
-    data_dir = click.prompt("Enter the full path of the "
-                            "directory where you'd like us to store data.",
-                            type=str,
-                            default=str(Path(".").resolve()))
+    data_dir = click.prompt(
+        "Enter the full path of the " "directory where you'd like us to store data.",
+        type=str,
+        default=str(Path(".").resolve()),
+    )
 
-    es_enabled = click.confirm("Would you like to enable Elasticsearch? For this to work "
-                               "when you run archivy, you must have ES installed."
-                               "See https://archivy.github.io/setup-search/ for more info.")
+    es_enabled = click.confirm(
+        "Would you like to enable Elasticsearch? For this to work "
+        "when you run archivy, you must have ES installed."
+        "See https://archivy.github.io/setup-search/ for more info."
+    )
     if es_enabled:
         config.SEARCH_CONF["enabled"] = 1
     else:
@@ -62,8 +68,12 @@ def init(ctx):
         if not ctx.invoke(create_admin, username=username, password=password):
             return
 
-    config.HOST = click.prompt("Host [localhost (127.0.0.1)]",
-                               type=str, default="127.0.0.1", show_default=False)
+    config.HOST = click.prompt(
+        "Host [localhost (127.0.0.1)]",
+        type=str,
+        default="127.0.0.1",
+        show_default=False,
+    )
 
     config.override({"USER_DIR": data_dir})
     app.config["USER_DIR"] = data_dir
@@ -72,8 +82,10 @@ def init(ctx):
     (Path(data_dir) / "data").mkdir(exist_ok=True, parents=True)
 
     write_config(vars(config))
-    click.echo("Config successfully created at "
-               + str((Path(app.config['INTERNAL_DIR']) / 'config.yml').resolve()))
+    click.echo(
+        "Config successfully created at "
+        + str((Path(app.config["INTERNAL_DIR"]) / "config.yml").resolve())
+    )
 
 
 @cli.command("config", short_help="Open archivy config.")
@@ -87,17 +99,19 @@ def hooks():
     if not hook_path.exists():
         print("aaaa")
         with hook_path.open("w") as f:
-            f.write("from archivy.config import BaseHooks\n"
-                    "class Hooks(BaseHooks):\n"
-                    "   # see available hooks at https://archivy.github.io/reference/hooks/\n"
-                    "   def on_dataobj_create(self, dataobj): # for example\n"
-                    "       pass")
+            f.write(
+                "from archivy.config import BaseHooks\n"
+                "class Hooks(BaseHooks):\n"
+                "   # see available hooks at https://archivy.github.io/reference/hooks/\n"
+                "   def on_dataobj_create(self, dataobj): # for example\n"
+                "       pass"
+            )
     open_file(hook_path)
 
 
 @cli.command("run", short_help="Runs archivy web application")
 def run():
-    click.echo('Running archivy...')
+    click.echo("Running archivy...")
     load_dotenv()
     environ["FLASK_RUN_FROM_CLI"] = "false"
     app_with_cli = create_click_web_app(click, cli, app)

--- a/archivy/click_web/__init__.py
+++ b/archivy/click_web/__init__.py
@@ -7,22 +7,22 @@ from flask import Blueprint
 
 from archivy.click_web.resources import cmd_exec, cmd_form, index
 
-jinja_env = jinja2.Environment(extensions=['jinja2.ext.do'])
+jinja_env = jinja2.Environment(extensions=["jinja2.ext.do"])
 
-'The full path to the click script file to execute.'
+"The full path to the click script file to execute."
 script_file = None
-'The click root command to serve'
+"The click root command to serve"
 click_root_cmd = None
 
 
 def _get_output_folder():
-    _output_folder = (Path(tempfile.gettempdir()) / 'click-web')
+    _output_folder = Path(tempfile.gettempdir()) / "click-web"
     if not _output_folder.exists():
         _output_folder.mkdir()
     return _output_folder
 
 
-'Where to place result files for download'
+"Where to place result files for download"
 OUTPUT_FOLDER = str(_get_output_folder())
 
 _flask_app = None
@@ -30,7 +30,7 @@ logger = None
 
 
 def create_click_web_app(module, command: click.BaseCommand, flask_app):
-    '''
+    """
     Create a Flask app that wraps a click command. (Call once)
 
     :param module: the module that contains the click command,
@@ -38,7 +38,7 @@ def create_click_web_app(module, command: click.BaseCommand, flask_app):
     :param command: The actual click root command, needed
     to be able to read the command tree and arguments
     in order to generate the index page and the html forms
-    '''
+    """
     global _flask_app, logger
     assert _flask_app is None, "Flask App already created."
 
@@ -47,18 +47,23 @@ def create_click_web_app(module, command: click.BaseCommand, flask_app):
     _flask_app = flask_app
 
     # add the "do" extension needed by our jinja templates
-    _flask_app.jinja_env.add_extension('jinja2.ext.do')
+    _flask_app.jinja_env.add_extension("jinja2.ext.do")
 
-    _flask_app.add_url_rule('/plugins', 'cli_index', index.index)
-    _flask_app.add_url_rule('/cli/<path:command_path>', 'command', cmd_form.get_form_for)
-    _flask_app.add_url_rule('/cli/<path:command_path>', 'command_execute', cmd_exec.exec,
-                            methods=['POST'])
+    _flask_app.add_url_rule("/plugins", "cli_index", index.index)
+    _flask_app.add_url_rule(
+        "/cli/<path:command_path>", "command", cmd_form.get_form_for
+    )
+    _flask_app.add_url_rule(
+        "/cli/<path:command_path>", "command_execute", cmd_exec.exec, methods=["POST"]
+    )
 
-    _flask_app.logger.info(f'OUTPUT_FOLDER: {OUTPUT_FOLDER}')
-    results_blueprint = Blueprint('results',
-                                  __name__,
-                                  static_url_path='/static/results',
-                                  static_folder=OUTPUT_FOLDER)
+    _flask_app.logger.info(f"OUTPUT_FOLDER: {OUTPUT_FOLDER}")
+    results_blueprint = Blueprint(
+        "results",
+        __name__,
+        static_url_path="/static/results",
+        static_folder=OUTPUT_FOLDER,
+    )
     _flask_app.register_blueprint(results_blueprint)
 
     logger = _flask_app.logger
@@ -67,12 +72,12 @@ def create_click_web_app(module, command: click.BaseCommand, flask_app):
 
 
 def _register(module, command: click.BaseCommand):
-    '''
+    """
     :param module: the module that contains the command, needed to get the path to the script.
     :param command: The actual click root command,
                     needed to be able to read the command tree and arguments
                     in order to generate the index page and the html forms
-    '''
+    """
     global click_root_cmd, script_file
     script_file = str(Path(module.__file__).absolute())
     click_root_cmd = command

--- a/archivy/click_web/resources/cmd_form.py
+++ b/archivy/click_web/resources/cmd_form.py
@@ -16,10 +16,12 @@ def get_form_for(command_path: str):
         return abort(404, str(err))
 
     levels = _generate_form_data(ctx_and_commands)
-    return render_template('click_web/command_form.html',
-                           levels=levels,
-                           command=levels[-1]['command'],
-                           command_path=command_path)
+    return render_template(
+        "click_web/command_form.html",
+        levels=levels,
+        command=levels[-1]["command"],
+        command_path=command_path,
+    )
 
 
 def _get_commands_by_path(command_path: str) -> Tuple[click.Context, click.Command]:
@@ -29,13 +31,15 @@ def _get_commands_by_path(command_path: str) -> Tuple[click.Context, click.Comma
     :return: Return a list from root to leaf commands.
     """
     command_path = "cli/" + command_path
-    command_path_items = command_path.split('/')
+    command_path_items = command_path.split("/")
     command_name, *command_path_items = command_path_items
     command = click_web.click_root_cmd
     if command.name != command_name:
         raise CommandNotFound(
-                'Failed to find root command {}. There is a root commande named: {}'
-                .format(command_name, command.name))
+            "Failed to find root command {}. There is a root commande named: {}".format(
+                command_name, command.name
+            )
+        )
     result = []
     with click.Context(command, info_name=command, parent=None) as ctx:
         result.append((ctx, command))
@@ -48,11 +52,12 @@ def _get_commands_by_path(command_path: str) -> Tuple[click.Context, click.Comma
                 ctx = click.Context(command, info_name=command, parent=ctx)
                 parent_command = command
             else:
-                raise CommandNotFound("""Failed to find command for path "{}".
-                                       Command "{}" not found. Must be one of {}"""
-                                      .format(command_path,
-                                              command_name,
-                                              parent_command.list_commands(ctx)))
+                raise CommandNotFound(
+                    """Failed to find command for path "{}".
+                                       Command "{}" not found. Must be one of {}""".format(
+                        command_path, command_name, parent_command.list_commands(ctx)
+                    )
+                )
             result.append((ctx, command))
     return result
 
@@ -69,9 +74,11 @@ def _generate_form_data(ctx_and_commands: List[Tuple[click.Context, click.Comman
         command.add_help_option = False
         command.html_help = _process_help(command.help)
 
-        input_fields = [get_input_field(ctx, param, command_index, param_index)
-                        for param_index, param in enumerate(command.get_params(ctx))]
-        levels.append({'command': command, 'fields': input_fields})
+        input_fields = [
+            get_input_field(ctx, param, command_index, param_index)
+            for param_index, param in enumerate(command.get_params(ctx))
+        ]
+        levels.append({"command": command, "fields": input_fields})
 
     return levels
 
@@ -87,7 +94,7 @@ def _process_help(help_text):
     """
     help = []
     in_pre = False
-    html_help = ''
+    html_help = ""
     if not help_text:
         return html_help
 
@@ -98,20 +105,20 @@ def _process_help(help_text):
             if in_pre and not line.strip():
                 # end of code block
                 in_pre = False
-                html_help += '\n'.join(help)
+                html_help += "\n".join(help)
                 help = []
-                help.append('</pre>')
+                help.append("</pre>")
                 continue
-            elif line.strip() == '\b':
+            elif line.strip() == "\b":
                 # start of code block
                 in_pre = True
-                html_help += '<br>\n'.join(help)
+                html_help += "<br>\n".join(help)
                 help = []
-                help.append('<pre>')
+                help.append("<pre>")
                 continue
             help.append(escape(line))
         except StopIteration:
             break
 
-    html_help += '\n'.join(help) if in_pre else '<br>\n'.join(help)
+    html_help += "\n".join(help) if in_pre else "<br>\n".join(help)
     return html_help

--- a/archivy/click_web/resources/index.py
+++ b/archivy/click_web/resources/index.py
@@ -7,39 +7,55 @@ from archivy import click_web
 
 
 def index():
-    with click.Context(click_web.click_root_cmd,
-                       info_name=click_web.click_root_cmd.name, parent=None) as ctx:
-        return render_template('click_web/show_tree.html',
-                               ctx=ctx, tree=_click_to_tree(ctx, click_web.click_root_cmd),
-                               title="Plugins")
+    with click.Context(
+        click_web.click_root_cmd, info_name=click_web.click_root_cmd.name, parent=None
+    ) as ctx:
+        return render_template(
+            "click_web/show_tree.html",
+            ctx=ctx,
+            tree=_click_to_tree(ctx, click_web.click_root_cmd),
+            title="Plugins",
+        )
 
 
 def _click_to_tree(ctx: click.Context, node: click.BaseCommand, ancestors=[]):
-    '''
+    """
     Convert a click root command to a tree of dicts and lists
     :return: a json like tree
-    '''
+    """
     res_childs = []
     res = OrderedDict()
-    res['is_group'] = isinstance(node, click.core.MultiCommand)
+    res["is_group"] = isinstance(node, click.core.MultiCommand)
     omitted = ["shell", "run", "routes", "create-admin"]
-    if res['is_group']:
+    if res["is_group"]:
         # a group, recurse for e    very child
         subcommand_names = set(click.Group.list_commands(node, ctx))
-        children = [node.get_command(ctx, key) for key in subcommand_names
-                    if key not in omitted]
+        children = [
+            node.get_command(ctx, key) for key in subcommand_names if key not in omitted
+        ]
         # Sort so commands comes before groups
-        children = sorted(children, key=lambda c: isinstance(c, click.core.MultiCommand))
+        children = sorted(
+            children, key=lambda c: isinstance(c, click.core.MultiCommand)
+        )
         for child in children:
-            res_childs.append(_click_to_tree(ctx, child, ancestors[:] + [node, ]))
+            res_childs.append(
+                _click_to_tree(
+                    ctx,
+                    child,
+                    ancestors[:]
+                    + [
+                        node,
+                    ],
+                )
+            )
 
-    res['name'] = node.name
+    res["name"] = node.name
 
     # Do not include any preformatted block (\b) for the short help.
-    res['short_help'] = node.get_short_help_str().split('\b')[0]
-    res['help'] = node.help
+    res["short_help"] = node.get_short_help_str().split("\b")[0]
+    res["help"] = node.help
     path_parts = ancestors + [node]
-    res['path'] = '/' + '/'.join(p.name for p in path_parts)
+    res["path"] = "/" + "/".join(p.name for p in path_parts)
     if res_childs:
-        res['childs'] = res_childs
+        res["childs"] = res_childs
     return res

--- a/archivy/click_web/resources/input_fields.py
+++ b/archivy/click_web/resources/input_fields.py
@@ -12,46 +12,56 @@ class FieldId:
         "0.0.option.text.text.--an-option"
         "0.1.argument.file[rb].text.an-argument"
     """
-    SEPARATOR = '.'
 
-    def __init__(self,
-                 command_index,
-                 param_index,
-                 param_type,
-                 click_type,
-                 nargs,
-                 form_type,
-                 name,
-                 key=None):
-        'the int index of the command it belongs to'
+    SEPARATOR = "."
+
+    def __init__(
+        self,
+        command_index,
+        param_index,
+        param_type,
+        click_type,
+        nargs,
+        form_type,
+        name,
+        key=None,
+    ):
+        "the int index of the command it belongs to"
         self.command_index = int(command_index)
-        'the int index for the ordering of paramters/arguments'
+        "the int index for the ordering of paramters/arguments"
         self.param_index = int(param_index)
-        'Type of option (argument, option, flag)'
+        "Type of option (argument, option, flag)"
         self.param_type = param_type
-        'Type of option (file, text)'
+        "Type of option (file, text)"
         self.click_type = click_type
-        'nargs value (-1 is variardic)'
+        "nargs value (-1 is variardic)"
         self.nargs = int(nargs)
-        'Type of html input type'
+        "Type of html input type"
         self.form_type = form_type
-        'The actual command line option (--debug)'
+        "The actual command line option (--debug)"
         self.name = name
-        'The actual form id'
+        "The actual form id"
         self.key = key if key else str(self)
 
     def __str__(self):
-        return self.SEPARATOR.join(str(p) for p in (self.command_index,
-                                                    self.param_index,
-                                                    self.param_type,
-                                                    self.click_type,
-                                                    self.nargs,
-                                                    self.form_type,
-                                                    self.name))
+        return self.SEPARATOR.join(
+            str(p)
+            for p in (
+                self.command_index,
+                self.param_index,
+                self.param_type,
+                self.click_type,
+                self.nargs,
+                self.form_type,
+                self.name,
+            )
+        )
 
     @classmethod
-    def from_string(cls, field_info_as_string) -> 'FieldId':
-        args = field_info_as_string.split(cls.SEPARATOR) + [field_info_as_string, ]
+    def from_string(cls, field_info_as_string) -> "FieldId":
+        args = field_info_as_string.split(cls.SEPARATOR) + [
+            field_info_as_string,
+        ]
         return cls(*args)
 
 
@@ -78,23 +88,23 @@ class BaseInput:
         field = {}
         param = self.param
 
-        field['param'] = param.param_type_name
-        if param.param_type_name == 'option':
-            name = '--{}'.format(self._to_cmd_line_name(param.name))
-            field['value'] = param.default if param.default else ''
-            field['checked'] = 'checked="checked"' if param.default else ''
-            field['desc'] = param.help
-            field['help'] = param.get_help_record(self.ctx)
-        elif param.param_type_name == 'argument':
+        field["param"] = param.param_type_name
+        if param.param_type_name == "option":
+            name = "--{}".format(self._to_cmd_line_name(param.name))
+            field["value"] = param.default if param.default else ""
+            field["checked"] = 'checked="checked"' if param.default else ""
+            field["desc"] = param.help
+            field["help"] = param.get_help_record(self.ctx)
+        elif param.param_type_name == "argument":
             name = self._to_cmd_line_name(param.name)
-            field['value'] = param.default
-            field['checked'] = ''
-            field['help'] = ''
+            field["value"] = param.default
+            field["checked"] = ""
+            field["help"] = ""
 
-        field['name'] = self._build_name(name)
-        field['required'] = param.required
-        field['nargs'] = param.nargs
-        field['human_readable_name'] = param.human_readable_name.replace('_', ' ')
+        field["name"] = self._build_name(name)
+        field["required"] = param.required
+        field["nargs"] = param.nargs
+        field["human_readable_name"] = param.human_readable_name.replace("_", " ")
         field.update(self.type_attrs)
         return field
 
@@ -107,7 +117,7 @@ class BaseInput:
         raise NotImplementedError()
 
     def _to_cmd_line_name(self, name: str) -> str:
-        return name.replace('_', '-')
+        return name.replace("_", "-")
 
     def _build_name(self, name: str):
         """
@@ -115,23 +125,27 @@ class BaseInput:
         what sub-command it belongs order index (for later sorting) and type of parameter.
         """
         # get the type of param to encode the in the name
-        if self.param.param_type_name == 'option':
-            param_type = 'flag' if self.param.is_bool_flag else 'option'
+        if self.param.param_type_name == "option":
+            param_type = "flag" if self.param.is_bool_flag else "option"
         else:
             param_type = self.param.param_type_name
 
-        click_type = self.type_attrs['click_type']
-        form_type = self.type_attrs['type']
+        click_type = self.type_attrs["click_type"]
+        form_type = self.type_attrs["type"]
 
         # in order for form to be have arguments for sub commands we need to add the
         # index of the command the argument belongs to
-        return str(FieldId(self.command_index,
-                           self.param_index,
-                           param_type,
-                           click_type,
-                           self.param.nargs,
-                           form_type,
-                           name))
+        return str(
+            FieldId(
+                self.command_index,
+                self.param_index,
+                param_type,
+                click_type,
+                self.param.nargs,
+                form_type,
+                name,
+            )
+        )
 
 
 class ChoiceInput(BaseInput):
@@ -140,28 +154,30 @@ class ChoiceInput(BaseInput):
     @property
     def type_attrs(self):
         type_attrs = {}
-        type_attrs['type'] = 'option'
-        type_attrs['options'] = self.param.type.choices
-        type_attrs['default'] = self.param.default
-        type_attrs['click_type'] = 'choice'
+        type_attrs["type"] = "option"
+        type_attrs["options"] = self.param.type.choices
+        type_attrs["default"] = self.param.default
+        type_attrs["click_type"] = "choice"
         return type_attrs
 
 
 class FlagInput(BaseInput):
-    def is_supported(self, ):
-        return self.param.param_type_name == 'option' and self.param.is_bool_flag
+    def is_supported(
+        self,
+    ):
+        return self.param.param_type_name == "option" and self.param.is_bool_flag
 
     @property
     def type_attrs(self):
         type_attrs = {}
-        type_attrs['type'] = 'checkbox'
-        type_attrs['click_type'] = 'bool_flag'
-        type_attrs['value'] = self.param.opts[0]
+        type_attrs["type"] = "checkbox"
+        type_attrs["click_type"] = "bool_flag"
+        type_attrs["value"] = self.param.opts[0]
         # the "on" value e.g ['--flag']
-        type_attrs['on_flag'] = self.param.opts[0]
+        type_attrs["on_flag"] = self.param.opts[0]
         # the "off" value e.g ['--no-flag']
         if self.param.secondary_opts:
-            type_attrs['off_flag'] = self.param.secondary_opts[0]
+            type_attrs["off_flag"] = self.param.secondary_opts[0]
         return type_attrs
 
 
@@ -171,9 +187,9 @@ class IntInput(BaseInput):
     @property
     def type_attrs(self):
         type_attrs = {}
-        type_attrs['type'] = 'number'
-        type_attrs['step'] = '1'
-        type_attrs['click_type'] = 'int'
+        type_attrs["type"] = "number"
+        type_attrs["step"] = "1"
+        type_attrs["click_type"] = "int"
         return type_attrs
 
 
@@ -183,14 +199,13 @@ class FloatInput(BaseInput):
     @property
     def type_attrs(self):
         type_attrs = {}
-        type_attrs['type'] = 'number'
-        type_attrs['step'] = 'any'
-        type_attrs['click_type'] = 'float'
+        type_attrs["type"] = "number"
+        type_attrs["step"] = "any"
+        type_attrs["click_type"] = "float"
         return type_attrs
 
 
 class FolderInput(BaseInput):
-
     def is_supported(self):
         if isinstance(self.param.type, click.Path):
             if self.param.type.dir_okay:
@@ -202,23 +217,22 @@ class FolderInput(BaseInput):
         type_attrs = {}
         # if it is required we treat it as an input folder
         # and only accept zip.
-        mode = 'r' if self.param.type.exists else 'w'
-        type_attrs['click_type'] = f'path[{mode}]'
+        mode = "r" if self.param.type.exists else "w"
+        type_attrs["click_type"] = f"path[{mode}]"
         if self.param.type.exists:
-            type_attrs['accept'] = "application/zip"
-            type_attrs['type'] = 'file'
+            type_attrs["accept"] = "application/zip"
+            type_attrs["type"] = "file"
         else:
-            type_attrs['type'] = 'hidden'
+            type_attrs["type"] = "hidden"
         return type_attrs
 
 
 class FileInput(BaseInput):
-
     def is_supported(self):
         if isinstance(self.param.type, click.File):
             return True
         elif isinstance(self.param.type, click.Path):
-            if (self.param.type.file_okay):
+            if self.param.type.file_okay:
                 return True
         return False
 
@@ -228,22 +242,22 @@ class FileInput(BaseInput):
         if isinstance(self.param.type, click.File):
             mode = self.param.type.mode
         elif isinstance(self.param.type, click.Path):
-            mode = 'w' if self.param.type.writable else ''
-            mode += 'r' if self.param.type.readable else ''
+            mode = "w" if self.param.type.writable else ""
+            mode += "r" if self.param.type.readable else ""
         else:
-            raise NotSupported(f'Illegal param type. Got type: {self.param.type}')
+            raise NotSupported(f"Illegal param type. Got type: {self.param.type}")
 
-        type_attrs['click_type'] = f'file[{mode}]'
+        type_attrs["click_type"] = f"file[{mode}]"
 
-        if 'r' not in mode:
+        if "r" not in mode:
             if self.param.required:
                 # if file is only for output do not show in form
-                type_attrs['type'] = 'hidden'
+                type_attrs["type"] = "hidden"
             else:
-                type_attrs['type'] = 'text'
+                type_attrs["type"] = "text"
 
         else:
-            type_attrs['type'] = 'file'
+            type_attrs["type"] = "file"
         return type_attrs
 
 
@@ -253,8 +267,8 @@ class EmailInput(BaseInput):
     @property
     def type_attrs(self):
         type_attrs = {}
-        type_attrs['type'] = 'email'
-        type_attrs['click_type'] = 'email'
+        type_attrs["type"] = "email"
+        type_attrs["click_type"] = "email"
         return type_attrs
 
 
@@ -264,8 +278,8 @@ class PasswordInput(BaseInput):
     @property
     def type_attrs(self):
         type_attrs = {}
-        type_attrs['type'] = 'password'
-        type_attrs['click_type'] = 'password'
+        type_attrs["type"] = "password"
+        type_attrs["click_type"] = "password"
         return type_attrs
 
 
@@ -275,32 +289,34 @@ class DefaultInput(BaseInput):
     @property
     def type_attrs(self):
         type_attrs = {}
-        type_attrs['type'] = 'text'
-        type_attrs['click_type'] = 'text'
+        type_attrs["type"] = "text"
+        type_attrs["click_type"] = "text"
         return type_attrs
 
 
-'''
+"""
 The types of inputs we support form inputs listed in priority order
 (first that matches will be selected).
 To add new Input handling for html forms for custom Parameter types
 just Subclass BaseInput and insert the class in the list.
-'''
-INPUT_TYPES = [ChoiceInput,
-               FlagInput,
-               IntInput,
-               FloatInput,
-               FolderInput,
-               FileInput,
-               EmailInput,
-               PasswordInput]
+"""
+INPUT_TYPES = [
+    ChoiceInput,
+    FlagInput,
+    IntInput,
+    FloatInput,
+    FolderInput,
+    FileInput,
+    EmailInput,
+    PasswordInput,
+]
 
 _DEFAULT_INPUT = [DefaultInput]
 
 
-def get_input_field(ctx: click.Context,
-                    param: click.Parameter,
-                    command_index, param_index) -> dict:
+def get_input_field(
+    ctx: click.Context, param: click.Parameter, command_index, param_index
+) -> dict:
     """
     Convert a click.Parameter into a dict structure describing a html form option
     """

--- a/archivy/click_web/web_click_types.py
+++ b/archivy/click_web/web_click_types.py
@@ -19,14 +19,14 @@ import click
 
 
 class EmailParamType(click.ParamType):
-    name = 'email'
+    name = "email"
     EMAIL_REGEX = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)")
 
     def convert(self, value, param, ctx):
         if self.EMAIL_REGEX.match(value):
             return value
         else:
-            self.fail(f'{value} is not a valid email', param, ctx)
+            self.fail(f"{value} is not a valid email", param, ctx)
 
 
 class PasswordParamType(click.ParamType):

--- a/archivy/config.py
+++ b/archivy/config.py
@@ -16,42 +16,35 @@ class Config(object):
         self.PANDOC_HIGHLIGHT_THEME = "pygments"
 
         self.SEARCH_CONF = {
-                "enabled": 0,
-                "url": "http://localhost:9200",
-                "index_name": "dataobj",
-                "search_conf": {
-                    "settings": {
-                        "highlight": {
-                            "max_analyzed_offset": 100000000
-                        },
-                        "analysis": {
-                            "analyzer": {
-                                "rebuilt_standard": {
-                                    "stopwords": "_english_",
-                                    "tokenizer": "standard",
-                                    "filter": [
-                                        "lowercase",
-                                        "kstem",
-                                        "trim",
-                                        "unique"
-                                    ]
-                                }
+            "enabled": 0,
+            "url": "http://localhost:9200",
+            "index_name": "dataobj",
+            "search_conf": {
+                "settings": {
+                    "highlight": {"max_analyzed_offset": 100000000},
+                    "analysis": {
+                        "analyzer": {
+                            "rebuilt_standard": {
+                                "stopwords": "_english_",
+                                "tokenizer": "standard",
+                                "filter": ["lowercase", "kstem", "trim", "unique"],
                             }
                         }
                     },
-                    "mappings": {
-                        "properties": {
-                            "title": {
-                                "type": "text",
-                                "analyzer": "rebuilt_standard",
-                                "term_vector": "with_positions_offsets"
-                            },
-                            "tags": {"type": "text", "analyzer": "rebuilt_standard"},
-                            "body": {"type": "text", "analyzer": "rebuilt_standard"},
-                        }
+                },
+                "mappings": {
+                    "properties": {
+                        "title": {
+                            "type": "text",
+                            "analyzer": "rebuilt_standard",
+                            "term_vector": "with_positions_offsets",
+                        },
+                        "tags": {"type": "text", "analyzer": "rebuilt_standard"},
+                        "body": {"type": "text", "analyzer": "rebuilt_standard"},
                     }
-                }
-            }
+                },
+            },
+        }
 
     def override(self, user_conf: dict):
         for k, v in user_conf.items():

--- a/archivy/data.py
+++ b/archivy/data.py
@@ -15,7 +15,7 @@ from archivy.search import remove_from_index
 # FIXME: ugly hack to make sure the app path is evaluated at the right time
 def get_data_dir():
     """Returns the directory where dataobjs are stored"""
-    return Path(current_app.config['USER_DIR']) / "data"
+    return Path(current_app.config["USER_DIR"]) / "data"
 
 
 def is_relative_to(sub_path, parent):
@@ -29,6 +29,7 @@ def is_relative_to(sub_path, parent):
 
 class Directory:
     """Tree like file-structure used to build file navigation in Archiv"""
+
     def __init__(self, name):
         self.name = name
         self.child_files = []
@@ -87,9 +88,9 @@ def get_items(collections=[], path="", structured=True, json_format=False):
         for filepath in root_dir.rglob("*.md"):
             data = frontmatter.load(filepath)
             data["fullpath"] = str(filepath.parent.relative_to(root_dir))
-            if len(collections) == 0 or \
-                    any([collection == data["type"]
-                        for collection in collections]):
+            if len(collections) == 0 or any(
+                [collection == data["type"] for collection in collections]
+            ):
                 if json_format:
                     dict_dataobj = data.__dict__
                     # remove unnecessary yaml handler
@@ -171,6 +172,7 @@ def update_item(dataobj_id, new_content):
     """
 
     from archivy.models import DataObj
+
     filename = get_by_id(dataobj_id)
     dataobj = frontmatter.load(filename)
     dataobj.content = new_content
@@ -179,7 +181,9 @@ def update_item(dataobj_id, new_content):
         f.write(md)
 
     converted_dataobj = DataObj.from_md(md)
-    converted_dataobj.fullpath = str(filename.relative_to(current_app.config["USER_DIR"]))
+    converted_dataobj.fullpath = str(
+        filename.relative_to(current_app.config["USER_DIR"])
+    )
     converted_dataobj.index()
     load_hooks().on_edit(converted_dataobj)
 
@@ -187,8 +191,11 @@ def update_item(dataobj_id, new_content):
 def get_dirs():
     """Gets all dir names where dataobjs are stored"""
     # join glob matchers
-    dirnames = [str(dir_path.relative_to(get_data_dir())) for dir_path
-                in get_data_dir().rglob("*") if dir_path.is_dir()]
+    dirnames = [
+        str(dir_path.relative_to(get_data_dir()))
+        for dir_path in get_data_dir().rglob("*")
+        if dir_path.is_dir()
+    ]
 
     # append name for root dir
     dirnames.append("not classified")
@@ -225,6 +232,7 @@ def format_file(path: str):
     """
 
     from archivy.models import DataObj
+
     data_dir = get_data_dir()
     path = Path(path)
     if not path.exists():
@@ -245,18 +253,19 @@ def format_file(path: str):
             datapath = Path()
 
         note_dataobj = {
-                "title": path.name.replace(".md", ""),
-                "content": file_contents,
-                "type": "note",
-                "path": str(datapath)
-            }
+            "title": path.name.replace(".md", ""),
+            "content": file_contents,
+            "type": "note",
+            "path": str(datapath),
+        }
 
         dataobj = DataObj(**note_dataobj)
         dataobj.insert()
 
         path.unlink()
         current_app.logger.info(
-                f"Formatted and moved {str(datapath / path.name)} to {dataobj.fullpath}")
+            f"Formatted and moved {str(datapath / path.name)} to {dataobj.fullpath}"
+        )
 
 
 def unformat_file(path: str, out_dir: str):
@@ -291,7 +300,9 @@ def unformat_file(path: str, out_dir: str):
         with new_path.open("w") as f:
             f.write(dataobj.content)
 
-        current_app.logger.info(f"Unformatted and moved {str(path)} to {str(new_path.resolve())}")
+        current_app.logger.info(
+            f"Unformatted and moved {str(path)} to {str(new_path.resolve())}"
+        )
         path.unlink()
 
 

--- a/archivy/helpers.py
+++ b/archivy/helpers.py
@@ -41,7 +41,7 @@ def get_db(force_reconnect=False):
     Returns the database object that you can use to
     store data persistently
     """
-    if 'db' not in g or force_reconnect:
+    if "db" not in g or force_reconnect:
         g.db = TinyDB(str(Path(current_app.config["INTERNAL_DIR"]) / "db.json"))
 
     return g.db

--- a/archivy/models.py
+++ b/archivy/models.py
@@ -70,25 +70,24 @@ class DataObj:
 
     __searchable__ = ["title", "content", "tags"]
 
-    id: Optional[int] = attrib(validator=optional(instance_of(int)),
-                               default=None)
+    id: Optional[int] = attrib(validator=optional(instance_of(int)), default=None)
     type: str = attrib(validator=instance_of(str))
     title: str = attrib(validator=instance_of(str), default="")
     content: str = attrib(validator=instance_of(str), default="")
     tags: List[str] = attrib(validator=instance_of(list), default=[])
-    url: Optional[str] = attrib(validator=optional(instance_of(str)),
-                                default=None)
+    url: Optional[str] = attrib(validator=optional(instance_of(str)), default=None)
     date: Optional[datetime] = attrib(
         validator=optional(instance_of(datetime)),
         default=None,
     )
     path: str = attrib(validator=instance_of(str), default="")
-    fullpath: Optional[str] = attrib(validator=optional(instance_of(str)),
-                                     default=None)
+    fullpath: Optional[str] = attrib(validator=optional(instance_of(str)), default=None)
 
     def process_bookmark_url(self):
         """Process url to get content for bookmark"""
-        if self.type not in ("bookmark", "pocket_bookmark") or not validators.url(self.url):
+        if self.type not in ("bookmark", "pocket_bookmark") or not validators.url(
+            self.url
+        ):
             return None
 
         try:
@@ -99,8 +98,7 @@ class DataObj:
             return
 
         try:
-            parsed_html = BeautifulSoup(url_request.text,
-                                        features="html.parser")
+            parsed_html = BeautifulSoup(url_request.text, features="html.parser")
         except Exception:
             flash(f"Could not parse {self.url}\n", "error")
             self.wipe()
@@ -113,8 +111,7 @@ class DataObj:
             return
 
         parsed_title = parsed_html.title
-        self.title = (parsed_title.string if parsed_title is not None
-                      else self.url)
+        self.title = parsed_title.string if parsed_title is not None else self.url
 
     def wipe(self):
         """Resets and invalidates dataobj"""
@@ -142,8 +139,11 @@ class DataObj:
                     # delete tag
                     tag.decompose()
 
-            elif tag.name == "img" and tag.has_attr("src") and (tag["src"].startswith("/")
-                                                                or tag["src"].startswith("./")):
+            elif (
+                tag.name == "img"
+                and tag.has_attr("src")
+                and (tag["src"].startswith("/") or tag["src"].startswith("./"))
+            ):
 
                 tag["src"] = urljoin(url, tag["src"])
 
@@ -153,11 +153,13 @@ class DataObj:
     def validate(self):
         """Verifies that the content matches required validation constraints"""
         valid_url = (self.type != "bookmark" or self.type != "pocket_bookmark") or (
-                    isinstance(self.url, str) and validators.url(self.url))
+            isinstance(self.url, str) and validators.url(self.url)
+        )
 
         valid_title = isinstance(self.title, str) and self.title != ""
-        valid_content = (self.type not in ("bookmark", "pocket_bookmark")
-                         or isinstance(self.content, str))
+        valid_content = self.type not in ("bookmark", "pocket_bookmark") or isinstance(
+            self.content, str
+        )
         return valid_url and valid_title and valid_content
 
     def insert(self):
@@ -177,7 +179,7 @@ class DataObj:
                 "date": self.date.strftime("%x").replace("/", "-"),
                 "tags": self.tags,
                 "id": self.id,
-                "path": self.path
+                "path": self.path,
             }
             if self.type == "bookmark" or self.type == "pocket_bookmark":
                 data["url"] = self.url
@@ -185,11 +187,13 @@ class DataObj:
             # convert to markdown file
             dataobj = frontmatter.Post(self.content)
             dataobj.metadata = data
-            self.fullpath = str(create(
-                                    frontmatter.dumps(dataobj),
-                                    f"{self.id}-{dataobj['title']}",
-                                    path=self.path,
-                                ))
+            self.fullpath = str(
+                create(
+                    frontmatter.dumps(dataobj),
+                    f"{self.id}-{dataobj['title']}",
+                    path=self.path,
+                )
+            )
 
             hooks.on_dataobj_create(self)
             self.index()
@@ -243,7 +247,9 @@ class User(UserMixin):
 
     username: str = attrib(validator=instance_of(str))
     password: Optional[str] = attrib(validator=optional(instance_of(str)), default=None)
-    is_admin: Optional[bool] = attrib(validator=optional(instance_of(bool)), default=None)
+    is_admin: Optional[bool] = attrib(
+        validator=optional(instance_of(bool)), default=None
+    )
     id: Optional[int] = attrib(validator=optional(instance_of(int)), default=False)
 
     def insert(self):
@@ -260,7 +266,7 @@ class User(UserMixin):
             "username": self.username,
             "hashed_password": hashed_password,
             "is_admin": self.is_admin,
-            "type": "user"
+            "type": "user",
         }
 
         helpers.load_hooks().on_user_create(self)

--- a/archivy/routes.py
+++ b/archivy/routes.py
@@ -24,9 +24,11 @@ def pass_defaults():
 
 @app.before_request
 def check_perms():
-    allowed_path = (request.path.startswith("/login") or
-                    request.path.startswith("/static") or
-                    request.path.startswith("/api/login"))
+    allowed_path = (
+        request.path.startswith("/login")
+        or request.path.startswith("/static")
+        or request.path.startswith("/api/login")
+    )
     if not current_user.is_authenticated and not allowed_path:
         return redirect(url_for("login", next=request.path))
     return
@@ -49,7 +51,7 @@ def index():
         dir=files,
         current_path=path,
         new_folder_form=forms.NewFolderForm(),
-        delete_form=forms.DeleteFolderForm()
+        delete_form=forms.DeleteFolderForm(),
     )
 
 
@@ -61,11 +63,7 @@ def new_bookmark():
     if form.validate_on_submit():
         path = form.path.data if form.path.data != "not classified" else ""
         tags = form.tags.data.split(",") if form.tags.data != "" else []
-        bookmark = DataObj(
-            url=form.url.data,
-            tags=tags,
-            path=path,
-            type="bookmark")
+        bookmark = DataObj(url=form.url.data, tags=tags, path=path, type="bookmark")
         bookmark.process_bookmark_url()
         bookmark_id = bookmark.insert()
         if bookmark_id:
@@ -73,13 +71,10 @@ def new_bookmark():
             return redirect(f"/dataobj/{bookmark_id}")
     # for bookmarklet
     form.url.data = request.args.get("url", "")
-    path = request.args.get("path", "not classified").strip('/')
+    path = request.args.get("path", "not classified").strip("/")
     # handle empty argument
     form.path.data = path if path != "" else "not classified"
-    return render_template(
-        "dataobjs/new.html",
-        title="New Bookmark",
-        form=form)
+    return render_template("dataobjs/new.html", title="New Bookmark", form=form)
 
 
 @app.route("/notes/new", methods=["GET", "POST"])
@@ -89,22 +84,15 @@ def new_note():
     if form.validate_on_submit():
         path = form.path.data if form.path.data != "not classified" else ""
         tags = form.tags.data.split(",") if form.tags.data != "" else []
-        note = DataObj(
-            title=form.title.data,
-            tags=tags,
-            path=path,
-            type="note")
+        note = DataObj(title=form.title.data, tags=tags, path=path, type="note")
         note_id = note.insert()
         if note_id:
             flash("Note Saved!", "success")
             return redirect(f"/dataobj/{note_id}")
-    path = request.args.get("path", "not classified").strip('/')
+    path = request.args.get("path", "not classified").strip("/")
     # handle empty argument
     form.path.data = path if path != "" else "not classified"
-    return render_template(
-        "/dataobjs/new.html",
-        title="New Note",
-        form=form)
+    return render_template("/dataobjs/new.html", title="New Note", form=form)
 
 
 @app.route("/dataobj/<dataobj_id>")
@@ -123,7 +111,8 @@ def show_dataobj(dataobj_id):
         title=dataobj["title"],
         dataobj=dataobj,
         current_path=dataobj["dir"],
-        form=forms.DeleteDataForm())
+        form=forms.DeleteDataForm(),
+    )
 
 
 @app.route("/dataobj/delete/<dataobj_id>", methods=["DELETE", "GET"])
@@ -142,7 +131,9 @@ def login():
     form = forms.UserForm()
     if form.validate_on_submit():
         db = get_db()
-        user = db.search((Query().username == form.username.data) & (Query().type == "user"))
+        user = db.search(
+            (Query().username == form.username.data) & (Query().type == "user")
+        )
 
         if user and check_password_hash(user[0]["hashed_password"], form.password.data):
             user = User.from_db(user[0])
@@ -172,9 +163,9 @@ def edit_user():
         db.update(
             {
                 "username": form.username.data,
-                "hashed_password": generate_password_hash(form.password.data)
+                "hashed_password": generate_password_hash(form.password.data),
             },
-            doc_ids=[current_user.id]
+            doc_ids=[current_user.id],
         )
         flash("Information saved!", "success")
         return redirect("/")

--- a/archivy/search.py
+++ b/archivy/search.py
@@ -18,7 +18,9 @@ def add_to_index(model):
     payload = {}
     for field in model.__searchable__:
         payload[field] = getattr(model, field)
-    es.index(index=current_app.config["SEARCH_CONF"]["index_name"], id=model.id, body=payload)
+    es.index(
+        index=current_app.config["SEARCH_CONF"]["index_name"], id=model.id, body=payload
+    )
     return True
 
 
@@ -42,7 +44,7 @@ def query_index(query):
                 "multi_match": {
                     "query": query,
                     "fields": ["*"],
-                    "analyzer": "rebuilt_standard"
+                    "analyzer": "rebuilt_standard",
                 }
             },
             "highlight": {
@@ -52,9 +54,9 @@ def query_index(query):
                         "pre_tags": "==",
                         "post_tags": "==",
                     }
-                }
-            }
-        }
+                },
+            },
+        },
     )
 
     hits = []

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ from archivy.models import DataObj, User
 
 _app = None
 
+
 @pytest.fixture
 def test_app():
     """Instantiate the app for each test with its own temporary data directory
@@ -23,7 +24,7 @@ def test_app():
     # create a temporary file to isolate the database for each test
     global _app
     if _app is None:
-        _app = create_click_web_app(cli, cli.cli, app) 
+        _app = create_click_web_app(cli, cli.cli, app)
     app_dir = tempfile.mkdtemp()
     _app.config["INTERNAL_DIR"] = app_dir
     _app.config["USER_DIR"] = app_dir
@@ -40,10 +41,7 @@ def test_app():
     # information.
     with _app.app_context():
         _ = get_db()
-        user = {
-            "username": "halcyon",
-            "password": "password"
-        }
+        user = {"username": "halcyon", "password": "password"}
 
         User(**user).insert()
         yield _app
@@ -85,8 +83,10 @@ def mocked_responses():
 @pytest.fixture
 def note_fixture(test_app):
     note_dict = {
-        "type": "note", "title": "Test Note",
-        "tags": ["testing", "archivy"], "path": ""
+        "type": "note",
+        "title": "Test Note",
+        "tags": ["testing", "archivy"],
+        "path": "",
     }
 
     with test_app.app_context():
@@ -97,7 +97,10 @@ def note_fixture(test_app):
 
 @pytest.fixture
 def bookmark_fixture(test_app, mocked_responses):
-    mocked_responses.add(responses.GET, "https://example.com/", body="""<html>
+    mocked_responses.add(
+        responses.GET,
+        "https://example.com/",
+        body="""<html>
         <head><title>Example</title></head><body><p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit
         <script>console.log("this should be sanitized")</script>
@@ -105,12 +108,15 @@ def bookmark_fixture(test_app, mocked_responses):
         <a href="/testing-absolute-url">link</a>
         <a href"/empty-link"></a>
         </p></body></html>
-    """)
+    """,
+    )
 
     datapoints = {
-        "type": "bookmark", "title": "Test Bookmark",
-        "tags": ["testing", "archivy"], "path": "",
-        "url": "https://example.com/"
+        "type": "bookmark",
+        "title": "Test Bookmark",
+        "tags": ["testing", "archivy"],
+        "path": "",
+        "url": "https://example.com/",
     }
 
     with test_app.app_context():
@@ -122,10 +128,7 @@ def bookmark_fixture(test_app, mocked_responses):
 
 @pytest.fixture()
 def user_fixture(test_app):
-    user = {
-        "username": "__username__",
-        "password": "__password__"
-    }
+    user = {"username": "__username__", "password": "__password__"}
 
     user = User(**user)
     user.insert()
@@ -147,19 +150,28 @@ def pocket_fixture(test_app, mocked_responses):
         "https://getpocket.com/v3/oauth/authorize",
         json={
             "access_token": "5678defg-5678-defg-5678-defg56",
-            "username": "test_user"
-        })
+            "username": "test_user",
+        },
+    )
 
     # fake /get response from pocket API
-    mocked_responses.add(responses.POST, "https://getpocket.com/v3/get", json={
-        'status': 1, 'complete': 1, 'list': {
-            '3088163616': {
-                'given_url': 'https://example.com', 'status': '0',
-                'resolved_url': 'https://example.com',
-                'excerpt': 'Lorem ipsum', 'is_article': '1',
+    mocked_responses.add(
+        responses.POST,
+        "https://getpocket.com/v3/get",
+        json={
+            "status": 1,
+            "complete": 1,
+            "list": {
+                "3088163616": {
+                    "given_url": "https://example.com",
+                    "status": "0",
+                    "resolved_url": "https://example.com",
+                    "excerpt": "Lorem ipsum",
+                    "is_article": "1",
+                },
             },
         },
-    })
+    )
 
     pocket_key = {
         "type": "pocket_key",
@@ -169,14 +181,17 @@ def pocket_fixture(test_app, mocked_responses):
     db.insert(pocket_key)
     return pocket_key
 
+
 @pytest.fixture()
 def click_cli():
     yield cli.cli
+
 
 @pytest.fixture()
 def ctx(click_cli):
     with click.Context(click_cli, info_name=click_cli, parent=None) as ctx:
         yield ctx
+
 
 @pytest.fixture()
 def cli_runner():

--- a/docs/example-plugin/archivy_extra_metadata/__init__.py
+++ b/docs/example-plugin/archivy_extra_metadata/__init__.py
@@ -3,16 +3,18 @@ from tinydb import Query
 from archivy.helpers import get_db
 from archivy import app
 
+
 @click.group()
 def extra_metadata():
     """`archivy_extra_metadata` plugin to add metadata to your notes."""
     pass
 
+
 @extra_metadata.command()
 @click.option("--author", required=True)
 @click.option("--location", required=True)
 def setup(author, location):
-    """Save metadata values."""    
+    """Save metadata values."""
     with app.app_context():
         # save data in db
         get_db().insert({"type": "metadata", "author": author, "location": location})
@@ -20,6 +22,6 @@ def setup(author, location):
 
 
 def add_metadata(dataobj):
-	with app.app_context():
-		metadata = get_db().search(Query().type == "metadata")[0]
-		dataobj.content += f"Made by {metadata['author']} in {metadata['location']}."
+    with app.app_context():
+        metadata = get_db().search(Query().type == "metadata")[0]
+        dataobj.content += f"Made by {metadata['author']} in {metadata['location']}."

--- a/docs/example-plugin/setup.py
+++ b/docs/example-plugin/setup.py
@@ -4,8 +4,8 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name='archivy_extra_metadata',
-    version='0.1.0',
+    name="archivy_extra_metadata",
+    version="0.1.0",
     author="Uzay-G",
     description=(
         "Archivy extension to add some metadata at the end of your notes / bookmarks."
@@ -16,8 +16,8 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     packages=find_packages(),
-    entry_points='''
+    entry_points="""
         [archivy.plugins]
         extra-metadata=archivy_extra_metadata:extra_metadata
-    '''
+    """,
 )

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,13 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-with open('requirements.txt', encoding='utf-8') as f:
-    all_reqs = f.read().split('\n')
-    install_requires = [x.strip() for x in all_reqs if not x.startswith('#')
-                        and not x.startswith("-e git")]
+with open("requirements.txt", encoding="utf-8") as f:
+    all_reqs = f.read().split("\n")
+    install_requires = [
+        x.strip()
+        for x in all_reqs
+        if not x.startswith("#") and not x.startswith("-e git")
+    ]
 
 setuptools.setup(
     name="archivy",
@@ -23,7 +26,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License"
+        "License :: OSI Approved :: MIT License",
     ],
     entry_points={
         "console_scripts": [
@@ -33,5 +36,5 @@ setuptools.setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=install_requires,
-    python_requires='>=3.6',
+    python_requires=">=3.6",
 )

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -7,19 +7,20 @@ from flask_login import current_user
 from responses import RequestsMock, GET
 from archivy.helpers import get_max_id, get_db
 
+
 def test_plugin_index(test_app, client: FlaskClient):
     resp = client.get("/plugins")
     assert resp.status_code == 200
-    assert b'Plugins' in resp.data
+    assert b"Plugins" in resp.data
 
     # random number is one of the seeded plugins we added for testing
-    assert b'random-number' in resp.data
+    assert b"random-number" in resp.data
 
 
 def test_get_command_form(test_app, client: FlaskClient):
     cmd_path = "/cli/test-plugin/random-number"
     resp = client.get(cmd_path)
-    
+
     command_input = b"2.0.argument.text.1.text.upper-bound"
     command_name = b"Random-Number"
 
@@ -31,17 +32,19 @@ def test_exec_random_command(test_app, client: FlaskClient):
     cmd_path = "/cli/test-plugin/random-number"
     upper_bound = 10
     cmd_data = {"2.0.argument.text.1.text.upper-bound": upper_bound}
-    
+
     resp = client.post(cmd_path, data=cmd_data)
-    
+
     assert resp.status_code == 200
     # check for random number <= 10 in response
     assert re.match("(0*(?:[1-9]?|10))", str(resp.data))
 
-def test_exec_command_app_context(test_app, note_fixture, bookmark_fixture, client: FlaskClient):
+
+def test_exec_command_app_context(
+    test_app, note_fixture, bookmark_fixture, client: FlaskClient
+):
     cmd_path = "/cli/test-plugin/get-random-dataobj-title"
     resp = client.post(cmd_path)
 
     assert resp.status_code == 200
     assert b"Test Note" or b"Example" in resp.data
-

--- a/tests/functional/test_routes.py
+++ b/tests/functional/test_routes.py
@@ -9,58 +9,64 @@ from archivy.data import get_dirs, create_dir
 
 
 def test_get_index(test_app, client: FlaskClient):
-    response = client.get('/')
+    response = client.get("/")
     assert response.status_code == 200
 
 
 def test_get_new_bookmark(test_app, client: FlaskClient):
-    response = client.get('/bookmarks/new')
+    response = client.get("/bookmarks/new")
     assert response.status_code == 200
 
 
 def test_post_new_bookmark_missing_fields(test_app, client: FlaskClient):
-    response = client.post('/bookmarks/new', data={
-        'submit': True
-    })
+    response = client.post("/bookmarks/new", data={"submit": True})
     assert response.status_code == 200
-    assert b'This field is required' in response.data
+    assert b"This field is required" in response.data
+
 
 def test_get_new_note(test_app, client: FlaskClient):
-    response = client.get('/notes/new')
+    response = client.get("/notes/new")
     assert response.status_code == 200
 
 
 def test_get_dataobj_not_found(test_app, client: FlaskClient):
-    response = client.get('/dataobj/1')
+    response = client.get("/dataobj/1")
     assert response.status_code == 302
 
 
 def test_get_dataobj(test_app, client: FlaskClient, note_fixture):
-    response = client.get('/dataobj/1')
+    response = client.get("/dataobj/1")
     assert response.status_code == 200
 
 
 def test_get_delete_dataobj_not_found(test_app, client: FlaskClient):
-    response = client.get('/dataobj/delete/1')
+    response = client.get("/dataobj/delete/1")
     assert response.status_code == 302
 
 
 def test_get_delete_dataobj(test_app, client: FlaskClient, note_fixture):
-    response = client.get('/dataobj/delete/1')
+    response = client.get("/dataobj/delete/1")
     assert response.status_code == 302
 
-def test_create_new_bookmark(test_app, client: FlaskClient, mocked_responses: RequestsMock):
-    mocked_responses.add(GET, "https://example.com/", body="""<html>
+
+def test_create_new_bookmark(
+    test_app, client: FlaskClient, mocked_responses: RequestsMock
+):
+    mocked_responses.add(
+        GET,
+        "https://example.com/",
+        body="""<html>
         <head><title>Random</title></head><body><p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit
         </p></body></html>
-    """)
+    """,
+    )
 
     bookmark_data = {
         "url": "https://example.com",
         "tags": "testing,bookmark",
         "path": "not classified",
-        "submit": "true"
+        "submit": "true",
     }
 
     resp = client.post("/bookmarks/new", data=bookmark_data)
@@ -72,16 +78,16 @@ def test_create_new_bookmark(test_app, client: FlaskClient, mocked_responses: Re
     assert b"testing, bookmark" in resp.data
     assert b"https://example.com" in resp.data
     assert b"Random" in resp.data
-    
+
+
 def test_create_note(test_app, client: FlaskClient):
 
     note_data = {
         "title": "Testing the create route",
         "tags": "testing,note",
         "path": "not classified",
-        "submit": "true"
+        "submit": "true",
     }
-
 
     resp = client.post("/notes/new", data=note_data)
     assert resp.status_code == 302
@@ -92,37 +98,53 @@ def test_create_note(test_app, client: FlaskClient):
     assert b"testing, note" in resp.data
     assert b"Testing the create route" in resp.data
 
+
 def test_logging_in(test_app, client: FlaskClient):
-    resp = client.post("/login", data={"username": "halcyon", "password": "password"}, follow_redirects=True)
+    resp = client.post(
+        "/login",
+        data={"username": "halcyon", "password": "password"},
+        follow_redirects=True,
+    )
     assert resp.status_code == 200
     assert request.path == "/"
     assert current_user
 
+
 def test_logging_in_with_invalid_creds(test_app, client: FlaskClient):
-    resp = client.post("/login", data={"username": "invalid", "password": "dasdasd"}, follow_redirects=True)
+    resp = client.post(
+        "/login",
+        data={"username": "invalid", "password": "dasdasd"},
+        follow_redirects=True,
+    )
     assert resp.status_code == 200
     assert request.path == "/login"
     assert b"Invalid credentials" in resp.data
-    
+
+
 def test_edit_user(test_app, client: FlaskClient):
     """Tests editing a user's info, logging out and then logging in with new info."""
 
     new_user = "new_halcyon"
     new_pass = "password2"
-    resp = client.post("/user/edit",
-                data={"username": new_user, "password": new_pass},
-                follow_redirects=True)
-    
+    resp = client.post(
+        "/user/edit",
+        data={"username": new_user, "password": new_pass},
+        follow_redirects=True,
+    )
+
     assert request.path == "/"
 
     client.delete("/logout")
 
-    resp = client.post("/login",
-                        data={"username": new_user, "password": new_pass},
-                        follow_redirects=True)
+    resp = client.post(
+        "/login",
+        data={"username": new_user, "password": new_pass},
+        follow_redirects=True,
+    )
     assert resp.status_code == 200
     assert request.path == "/"
     # check information has updated.
+
 
 def test_logging_out(test_app, client: FlaskClient):
     """Tests logging out and then accessing restricted views"""
@@ -136,19 +158,22 @@ def test_logging_out(test_app, client: FlaskClient):
 def test_create_dir(test_app, client: FlaskClient):
     """Tests /folders/create endpoint"""
 
-    resp = client.post("/folders/create",
-                data={"parent_dir": "", "new_dir": "testing"},
-                follow_redirects=True)
+    resp = client.post(
+        "/folders/create",
+        data={"parent_dir": "", "new_dir": "testing"},
+        follow_redirects=True,
+    )
 
     assert resp.status_code == 200
     assert request.args.get("path") == "testing"
     assert "testing" in get_dirs()
     assert b"Folder successfully created" in resp.data
 
+
 def test_creating_without_dirname_fails(test_app, client: FlaskClient):
-    resp = client.post("/folders/create",
-                data={"parent_dir": ""},
-                follow_redirects=True)
+    resp = client.post(
+        "/folders/create", data={"parent_dir": ""}, follow_redirects=True
+    )
 
     assert resp.status_code == 200
     assert request.path == "/"
@@ -163,7 +188,9 @@ def test_visiting_nonexistent_dir_fails(test_app, client: FlaskClient):
 def test_deleting_dir(test_app, client: FlaskClient):
     create_dir("testing")
     assert "testing" in get_dirs()
-    resp = client.post("/folders/delete", data={"dir_name": "testing"}, follow_redirects=True)
+    resp = client.post(
+        "/folders/delete", data={"dir_name": "testing"}, follow_redirects=True
+    )
     assert not "testing" in get_dirs()
     assert b"Folder successfully deleted." in resp.data
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -6,6 +6,7 @@ from flask.testing import FlaskClient
 from archivy.data import create_dir, get_items
 from archivy.models import DataObj
 
+
 def test_bookmark_not_found(test_app, client: FlaskClient):
     response: Flask.response_class = client.get("/api/dataobjs/1")
     assert response.status_code == 404
@@ -21,11 +22,14 @@ def test_get_dataobj(test_app, client: FlaskClient, bookmark_fixture):
 
 def test_create_bookmark(test_app, client: FlaskClient, mocked_responses):
     mocked_responses.add(responses.GET, "http://example.org", body="Example\n")
-    response: Flask.response_class = client.post("/api/bookmarks", json={
-        "url": "http://example.org",
-        "tags": ["test"],
-        "path": "",
-    })
+    response: Flask.response_class = client.post(
+        "/api/bookmarks",
+        json={
+            "url": "http://example.org",
+            "tags": ["test"],
+            "path": "",
+        },
+    )
     assert response.status_code == 200
 
     response: Flask.response_class = client.get("/api/dataobjs/1")
@@ -34,14 +38,18 @@ def test_create_bookmark(test_app, client: FlaskClient, mocked_responses):
     assert response.json["dataobj_id"] == 1
     assert response.json["content"] == "Example"
 
+
 def test_create_note(test_app, client: FlaskClient, mocked_responses):
     mocked_responses.add(responses.GET, "http://example.org", body="Example\n")
-    response: Flask.response_class = client.post("/api/notes", json={
-        "title": "Test Note created with api",
-        "content": "Example",
-        "tags": ["test"],
-        "path": "",
-    })
+    response: Flask.response_class = client.post(
+        "/api/notes",
+        json={
+            "title": "Test Note created with api",
+            "content": "Example",
+            "tags": ["test"],
+            "path": "",
+        },
+    )
     assert response.status_code == 200
 
     response: Flask.response_class = client.get("/api/dataobjs/1")
@@ -70,8 +78,10 @@ def test_get_bookmarks_with_empty_db(test_app, client: FlaskClient):
 def test_get_dataobjs(test_app, client: FlaskClient, bookmark_fixture):
 
     note_dict = {
-        "type": "note", "title": "Nested Test Note",
-        "tags": ["testing", "archivy"], "path": "t"
+        "type": "note",
+        "title": "Nested Test Note",
+        "tags": ["testing", "archivy"],
+        "path": "t",
     }
 
     create_dir("t")
@@ -92,9 +102,7 @@ def test_get_dataobjs(test_app, client: FlaskClient, bookmark_fixture):
 
 def test_update_dataobj(test_app, client: FlaskClient, note_fixture):
     lorem = "Updated note content"
-    resp = client.put("/api/dataobjs/1", json={
-        "content": lorem
-    })
+    resp = client.put("/api/dataobjs/1", json={"content": lorem})
 
     assert resp.status_code == 200
 
@@ -103,9 +111,7 @@ def test_update_dataobj(test_app, client: FlaskClient, note_fixture):
 
 
 def test_updating_inexistent_dataobj_returns(test_app, client: FlaskClient):
-    resp = client.put("/api/dataobjs/1", json={
-        "content": "test"
-    })
+    resp = client.put("/api/dataobjs/1", json={"content": "test"})
 
     assert resp.status_code == 404
 
@@ -114,12 +120,15 @@ def test_api_login(test_app, client: FlaskClient):
     # logout
     client.delete("/logout")
     # requires converting to base64 for http basic auth
-    authorization = "Basic " + b64encode('halcyon:password'.encode('ascii')).decode('ascii')
+    authorization = "Basic " + b64encode("halcyon:password".encode("ascii")).decode(
+        "ascii"
+    )
     resp = client.post("/api/login", headers={"Authorization": authorization})
-    
+
     assert resp.status_code == 200
     resp = client.get("/api/dataobjs")
     assert resp.status_code == 200
+
 
 def test_unlogged_in_api_fails(test_app, client: FlaskClient):
     client.delete("/logout")
@@ -130,7 +139,6 @@ def test_unlogged_in_api_fails(test_app, client: FlaskClient):
 def test_deleting_unrelated_user_dir_fails(test_app, client: FlaskClient):
     resp = client.delete("/api/folders/delete", json={"path": "/dev/null"})
     assert resp.status_code == 400
-
 
 
 def test_path_injection_fails(test_app, client: FlaskClient):

--- a/tests/test_click_web.py
+++ b/tests/test_click_web.py
@@ -9,69 +9,119 @@ from archivy.click_web.resources import cmd_form, input_fields
 
 
 @pytest.mark.parametrize(
-    'param, command_index, expected',
+    "param, command_index, expected",
     [
-        (click.Argument(["an_argument", ]), 0,
-         {'checked': '',
-          'click_type': 'text',
-          'help': '',
-          'human_readable_name': 'AN ARGUMENT',
-          'name': '0.0.argument.text.1.text.an-argument',
-          'nargs': 1,
-          'param': 'argument',
-          'required': True,
-          'type': 'text',
-          'value': None}),
-        (click.Argument(["an_argument", ], nargs=2), 1,
-         {'checked': '',
-          'click_type': 'text',
-          'help': '',
-          'human_readable_name': 'AN ARGUMENT',
-          'name': '1.0.argument.text.2.text.an-argument',
-          'nargs': 2,
-          'param': 'argument',
-          'required': True,
-          'type': 'text',
-          'value': None}),
-        (click.Option(["--an_option", ]), 0,
-         {'checked': '',
-          'click_type': 'text',
-          'desc': None,
-          'help': ('--an_option TEXT', ''),
-          'human_readable_name': 'an option',
-          'name': '0.0.option.text.1.text.--an-option',
-          'nargs': 1,
-          'param': 'option',
-          'required': False,
-          'type': 'text',
-          'value': ''}),
-        (click.Option(["--an_option", ], nargs=2), 1,
-         {'checked': '',
-          'click_type': 'text',
-          'desc': None,
-          'help': ('--an_option TEXT...', ''),
-          'human_readable_name': 'an option',
-          'name': '1.0.option.text.2.text.--an-option',
-          'nargs': 2,
-          'param': 'option',
-          'required': False,
-          'type': 'text',
-          'value': ''}),
-        (click.Option(["--flag/--no-flag", ], default=True, help='help'), 3,
-         {'checked': 'checked="checked"',
-          'click_type': 'bool_flag',
-          'desc': 'help',
-          'help': ('--flag / --no-flag', 'help'),
-          'human_readable_name': 'flag',
-          'name': '3.0.flag.bool_flag.1.checkbox.--flag',
-          'nargs': 1,
-          'off_flag': '--no-flag',
-          'on_flag': '--flag',
-          'param': 'option',
-          'required': False,
-          'type': 'checkbox',
-          'value': '--flag'}),
-    ])
+        (
+            click.Argument(
+                [
+                    "an_argument",
+                ]
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "text",
+                "help": "",
+                "human_readable_name": "AN ARGUMENT",
+                "name": "0.0.argument.text.1.text.an-argument",
+                "nargs": 1,
+                "param": "argument",
+                "required": True,
+                "type": "text",
+                "value": None,
+            },
+        ),
+        (
+            click.Argument(
+                [
+                    "an_argument",
+                ],
+                nargs=2,
+            ),
+            1,
+            {
+                "checked": "",
+                "click_type": "text",
+                "help": "",
+                "human_readable_name": "AN ARGUMENT",
+                "name": "1.0.argument.text.2.text.an-argument",
+                "nargs": 2,
+                "param": "argument",
+                "required": True,
+                "type": "text",
+                "value": None,
+            },
+        ),
+        (
+            click.Option(
+                [
+                    "--an_option",
+                ]
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "text",
+                "desc": None,
+                "help": ("--an_option TEXT", ""),
+                "human_readable_name": "an option",
+                "name": "0.0.option.text.1.text.--an-option",
+                "nargs": 1,
+                "param": "option",
+                "required": False,
+                "type": "text",
+                "value": "",
+            },
+        ),
+        (
+            click.Option(
+                [
+                    "--an_option",
+                ],
+                nargs=2,
+            ),
+            1,
+            {
+                "checked": "",
+                "click_type": "text",
+                "desc": None,
+                "help": ("--an_option TEXT...", ""),
+                "human_readable_name": "an option",
+                "name": "1.0.option.text.2.text.--an-option",
+                "nargs": 2,
+                "param": "option",
+                "required": False,
+                "type": "text",
+                "value": "",
+            },
+        ),
+        (
+            click.Option(
+                [
+                    "--flag/--no-flag",
+                ],
+                default=True,
+                help="help",
+            ),
+            3,
+            {
+                "checked": 'checked="checked"',
+                "click_type": "bool_flag",
+                "desc": "help",
+                "help": ("--flag / --no-flag", "help"),
+                "human_readable_name": "flag",
+                "name": "3.0.flag.bool_flag.1.checkbox.--flag",
+                "nargs": 1,
+                "off_flag": "--no-flag",
+                "on_flag": "--flag",
+                "param": "option",
+                "required": False,
+                "type": "checkbox",
+                "value": "--flag",
+            },
+        ),
+    ],
+)
 def test_get_input_field(ctx, click_cli, param, expected, command_index):
     res = input_fields.get_input_field(ctx, param, command_index, 0)
     pprint.pprint(res)
@@ -79,20 +129,31 @@ def test_get_input_field(ctx, click_cli, param, expected, command_index):
 
 
 @pytest.mark.parametrize(
-    'param, command_index, expected',
+    "param, command_index, expected",
     [
-        (click.Argument(["an_argument", ], nargs=-1), 0,
-         {'checked': '',
-          'click_type': 'text',
-          'help': '',
-          'human_readable_name': 'AN ARGUMENT',
-          'name': '0.0.argument.text.-1.text.an-argument',
-          'nargs': -1,
-          'param': 'argument',
-          'required': False,
-          'type': 'text',
-          'value': None}),
-    ])
+        (
+            click.Argument(
+                [
+                    "an_argument",
+                ],
+                nargs=-1,
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "text",
+                "help": "",
+                "human_readable_name": "AN ARGUMENT",
+                "name": "0.0.argument.text.-1.text.an-argument",
+                "nargs": -1,
+                "param": "argument",
+                "required": False,
+                "type": "text",
+                "value": None,
+            },
+        ),
+    ],
+)
 def test_variadic_arguments(ctx, click_cli, param, expected, command_index):
     res = input_fields.get_input_field(ctx, param, command_index, 0)
     pprint.pprint(res)
@@ -100,32 +161,53 @@ def test_variadic_arguments(ctx, click_cli, param, expected, command_index):
 
 
 @pytest.mark.parametrize(
-    'param, command_index, expected',
+    "param, command_index, expected",
     [
-        (click.Argument(["a_file_argument", ], type=click.File('rb')), 0,
-         {'checked': '',
-          'click_type': 'file[rb]',
-          'help': '',
-          'human_readable_name': 'A FILE ARGUMENT',
-          'name': '0.0.argument.file[rb].1.file.a-file-argument',
-          'nargs': 1,
-          'param': 'argument',
-          'required': True,
-          'type': 'file',
-          'value': None}),
-        (click.Option(["--a_file_option", ], type=click.File('rb')), 0,
-         {'checked': '',
-          'click_type': 'file[rb]',
-          'desc': None,
-          'help': ('--a_file_option FILENAME', ''),
-          'human_readable_name': 'a file option',
-          'name': '0.0.option.file[rb].1.file.--a-file-option',
-          'nargs': 1,
-          'param': 'option',
-          'required': False,
-          'type': 'file',
-          'value': ''}),
-    ])
+        (
+            click.Argument(
+                [
+                    "a_file_argument",
+                ],
+                type=click.File("rb"),
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "file[rb]",
+                "help": "",
+                "human_readable_name": "A FILE ARGUMENT",
+                "name": "0.0.argument.file[rb].1.file.a-file-argument",
+                "nargs": 1,
+                "param": "argument",
+                "required": True,
+                "type": "file",
+                "value": None,
+            },
+        ),
+        (
+            click.Option(
+                [
+                    "--a_file_option",
+                ],
+                type=click.File("rb"),
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "file[rb]",
+                "desc": None,
+                "help": ("--a_file_option FILENAME", ""),
+                "human_readable_name": "a file option",
+                "name": "0.0.option.file[rb].1.file.--a-file-option",
+                "nargs": 1,
+                "param": "option",
+                "required": False,
+                "type": "file",
+                "value": "",
+            },
+        ),
+    ],
+)
 def test_get_file_input_field(ctx, click_cli, param, expected, command_index):
     res = input_fields.get_input_field(ctx, param, command_index, 0)
     pprint.pprint(res)
@@ -133,32 +215,53 @@ def test_get_file_input_field(ctx, click_cli, param, expected, command_index):
 
 
 @pytest.mark.parametrize(
-    'param, command_index, expected',
+    "param, command_index, expected",
     [
-        (click.Argument(["a_file_argument", ], type=click.File('wb')), 0,
-         {'checked': '',
-          'click_type': 'file[wb]',
-          'help': '',
-          'human_readable_name': 'A FILE ARGUMENT',
-          'name': '0.0.argument.file[wb].1.hidden.a-file-argument',
-          'nargs': 1,
-          'param': 'argument',
-          'required': True,
-          'type': 'hidden',
-          'value': None}),
-        (click.Option(["--a_file_option", ], type=click.File('wb')), 0,
-         {'checked': '',
-          'click_type': 'file[wb]',
-          'desc': None,
-          'help': ('--a_file_option FILENAME', ''),
-          'human_readable_name': 'a file option',
-          'name': '0.0.option.file[wb].1.text.--a-file-option',
-          'nargs': 1,
-          'param': 'option',
-          'required': False,
-          'type': 'text',
-          'value': ''}),
-    ])
+        (
+            click.Argument(
+                [
+                    "a_file_argument",
+                ],
+                type=click.File("wb"),
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "file[wb]",
+                "help": "",
+                "human_readable_name": "A FILE ARGUMENT",
+                "name": "0.0.argument.file[wb].1.hidden.a-file-argument",
+                "nargs": 1,
+                "param": "argument",
+                "required": True,
+                "type": "hidden",
+                "value": None,
+            },
+        ),
+        (
+            click.Option(
+                [
+                    "--a_file_option",
+                ],
+                type=click.File("wb"),
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "file[wb]",
+                "desc": None,
+                "help": ("--a_file_option FILENAME", ""),
+                "human_readable_name": "a file option",
+                "name": "0.0.option.file[wb].1.text.--a-file-option",
+                "nargs": 1,
+                "param": "option",
+                "required": False,
+                "type": "text",
+                "value": "",
+            },
+        ),
+    ],
+)
 def test_get_output_file_input_field(ctx, click_cli, param, expected, command_index):
     res = input_fields.get_input_field(ctx, param, command_index, 0)
     pprint.pprint(res)

--- a/tests/test_plugin/plugin.py
+++ b/tests/test_plugin/plugin.py
@@ -7,19 +7,20 @@ from archivy import app
 from archivy.helpers import get_max_id
 from archivy.data import get_items
 
+
 @click.group()
 def test_plugin():
     pass
+
 
 @test_plugin.command()
 @click.argument("upper_bound")
 def random_number(upper_bound):
     click.echo(randint(1, int(upper_bound)))
 
+
 @test_plugin.command()
 def get_random_dataobj_title():
     with app.app_context():
         dataobjs = get_items(structured=False)
         click.echo(dataobjs[randint(0, len(dataobjs))]["title"])
-
-

--- a/tests/test_plugin/setup.py
+++ b/tests/test_plugin/setup.py
@@ -1,13 +1,12 @@
-
 from setuptools import setup
 
 
 setup(
-    name='plugins2',
-    version='0.1dev0',
-    py_modules=['plugin'],
-    entry_points='''
+    name="plugins2",
+    version="0.1dev0",
+    py_modules=["plugin"],
+    entry_points="""
         [archivy.plugins]
         test_plugin=plugin:test_plugin
-    '''
+    """,
 )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -18,14 +18,18 @@ def test_initialization(test_app, cli_runner, click_cli):
     except FileNotFoundError:
         pass
     old_data_dir = test_app.config["USER_DIR"]
-    
+
     with cli_runner.isolated_filesystem():
         # create user, localhost, and don't use ES
-        res = cli_runner.invoke(click_cli, ["init"], input="\nn\ny\nusername\npassword\npassword\n\n")
+        res = cli_runner.invoke(
+            click_cli, ["init"], input="\nn\ny\nusername\npassword\npassword\n\n"
+        )
         assert "Config successfully created" in res.output
 
         # verify user was created
-        assert len(get_db().search(Query().type == "user" and Query().username == "username"))
+        assert len(
+            get_db().search(Query().type == "user" and Query().username == "username")
+        )
 
         # verify dataobj creation works
         assert DataObj(type="note", title="Test note").insert()
@@ -45,11 +49,10 @@ def test_initialization(test_app, cli_runner, click_cli):
     assert old_data_dir != test_app.config["USER_DIR"]
 
 
-
 def test_initialization_with_es(test_app, cli_runner, click_cli):
     conf_path = os.path.join(test_app.config["USER_DIR"], "config.yml")
     old_data_dir = test_app.config["USER_DIR"]
-    
+
     with cli_runner.isolated_filesystem():
         # use ES, localhost and don't create user
         res = cli_runner.invoke(click_cli, ["init"], input="\ny\nn\n\n")
@@ -70,7 +73,7 @@ def test_initialization_with_es(test_app, cli_runner, click_cli):
 def test_initialization_in_diff_than_curr_dir(test_app, cli_runner, click_cli):
     conf_path = os.path.join(test_app.config["USER_DIR"], "config.yml")
     data_dir = mkdtemp()
-    
+
     with cli_runner.isolated_filesystem():
         # input data dir - localhost - don't use ES and don't create user
         res = cli_runner.invoke(cli, ["init"], input=f"{data_dir}\nn\nn\n\n")
@@ -79,7 +82,6 @@ def test_initialization_in_diff_than_curr_dir(test_app, cli_runner, click_cli):
     conf = open(conf_path).read()
 
     assert f"USER_DIR: {data_dir}" in conf
-
 
     # check initialization in random directory
     # has resulted in change of user dir
@@ -98,11 +100,10 @@ def test_initialization_custom_host(test_app, cli_runner, click_cli):
         assert False
     except FileNotFoundError:
         pass
-    
+
     with cli_runner.isolated_filesystem():
         # create user, localhost, and don't use ES
-        res = cli_runner.invoke(click_cli, ["init"],
-                input="\nn\nn\n0.0.0.0")
+        res = cli_runner.invoke(click_cli, ["init"], input="\nn\nn\n0.0.0.0")
         assert "Host" in res.output
         assert "Config successfully created" in res.output
 
@@ -116,9 +117,9 @@ def test_initialization_custom_host(test_app, cli_runner, click_cli):
 def test_create_admin(test_app, cli_runner, click_cli):
     db = get_db()
     nb_users = len(db.search(Query().type == "user"))
-    cli_runner.invoke(click_cli,
-                       ["create-admin", "__username__"],
-                       input="password\npassword")
+    cli_runner.invoke(
+        click_cli, ["create-admin", "__username__"], input="password\npassword"
+    )
 
     # need to reconnect to db because it has been modified by different processes
     # so the connection needs to be updated for new changes
@@ -126,12 +127,13 @@ def test_create_admin(test_app, cli_runner, click_cli):
     assert nb_users + 1 == len(db.search(Query().type == "user"))
     assert len(db.search(Query().type == "user" and Query().username == "__username__"))
 
+
 def test_create_admin_small_password_fails(test_app, cli_runner, click_cli):
-    cli_runner.invoke(click_cli,
-                       ["create-admin", "__username__"],
-                       input="short\nshort")
+    cli_runner.invoke(click_cli, ["create-admin", "__username__"], input="short\nshort")
     db = get_db()
-    assert not len(db.search(Query().type == "user" and Query().username == "__username__"))
+    assert not len(
+        db.search(Query().type == "user" and Query().username == "__username__")
+    )
 
 
 def test_format_multiple_md_file(test_app, cli_runner, click_cli):
@@ -146,9 +148,14 @@ def test_format_multiple_md_file(test_app, cli_runner, click_cli):
         for filename in files:
             assert f"Formatted and moved {filename}" in res.output
 
+
 def test_format_entire_directory(test_app, cli_runner, click_cli):
     with cli_runner.isolated_filesystem():
-        files = ["unformatted/test-note-1.md", "unformatted/test-note-2.md", "unformatted/nested/test-note-3.md"]
+        files = [
+            "unformatted/test-note-1.md",
+            "unformatted/test-note-2.md",
+            "unformatted/nested/test-note-3.md",
+        ]
         os.mkdir("data")
         os.mkdir("data/unformatted")
         os.mkdir("data/unformatted/nested")
@@ -166,18 +173,36 @@ def test_format_entire_directory(test_app, cli_runner, click_cli):
         for filename in files:
             # assert directory files got moved correctly
             assert f"Formatted and moved {filename}" in res.output
-        assert(os.path.abspath("") + "/data/unformatted") in res.output
+        assert (os.path.abspath("") + "/data/unformatted") in res.output
 
 
-def test_unformat_multiple_md_file(test_app, cli_runner, click_cli, bookmark_fixture, note_fixture):
+def test_unformat_multiple_md_file(
+    test_app, cli_runner, click_cli, bookmark_fixture, note_fixture
+):
     out_dir = mkdtemp()
     create_dir("")
-    res = cli_runner.invoke(cli, ["unformat", str(bookmark_fixture.fullpath), str(note_fixture.fullpath), out_dir])
-    assert f"Unformatted and moved {bookmark_fixture.fullpath} to {out_dir}/{bookmark_fixture.title}" in res.output
-    assert f"Unformatted and moved {note_fixture.fullpath} to {out_dir}/{note_fixture.title}" in res.output
+    res = cli_runner.invoke(
+        cli,
+        [
+            "unformat",
+            str(bookmark_fixture.fullpath),
+            str(note_fixture.fullpath),
+            out_dir,
+        ],
+    )
+    assert (
+        f"Unformatted and moved {bookmark_fixture.fullpath} to {out_dir}/{bookmark_fixture.title}"
+        in res.output
+    )
+    assert (
+        f"Unformatted and moved {note_fixture.fullpath} to {out_dir}/{note_fixture.title}"
+        in res.output
+    )
 
 
-def test_unformat_directory(test_app, cli_runner, click_cli, bookmark_fixture, note_fixture):
+def test_unformat_directory(
+    test_app, cli_runner, click_cli, bookmark_fixture, note_fixture
+):
     out_dir = mkdtemp()
 
     # create directory to store archivy note
@@ -187,5 +212,10 @@ def test_unformat_directory(test_app, cli_runner, click_cli, bookmark_fixture, n
     nested_note.insert()
 
     # unformat directory
-    res = cli_runner.invoke(cli, ["unformat", os.path.join(get_data_dir(), note_dir), out_dir])
-    assert f"Unformatted and moved {nested_note.fullpath} to {out_dir}/{note_dir}/{nested_note.title}" in res.output
+    res = cli_runner.invoke(
+        cli, ["unformat", os.path.join(get_data_dir(), note_dir), out_dir]
+    )
+    assert (
+        f"Unformatted and moved {nested_note.fullpath} to {out_dir}/{note_dir}/{nested_note.title}"
+        in res.output
+    )

--- a/tests/unit/test_click_web.py
+++ b/tests/unit/test_click_web.py
@@ -11,69 +11,119 @@ from archivy.click_web.resources.cmd_exec import RequestToCommandArgs
 
 
 @pytest.mark.parametrize(
-    'param, command_index, expected',
+    "param, command_index, expected",
     [
-        (click.Argument(["an_argument", ]), 0,
-         {'checked': '',
-          'click_type': 'text',
-          'help': '',
-          'human_readable_name': 'AN ARGUMENT',
-          'name': '0.0.argument.text.1.text.an-argument',
-          'nargs': 1,
-          'param': 'argument',
-          'required': True,
-          'type': 'text',
-          'value': None}),
-        (click.Argument(["an_argument", ], nargs=2), 1,
-         {'checked': '',
-          'click_type': 'text',
-          'help': '',
-          'human_readable_name': 'AN ARGUMENT',
-          'name': '1.0.argument.text.2.text.an-argument',
-          'nargs': 2,
-          'param': 'argument',
-          'required': True,
-          'type': 'text',
-          'value': None}),
-        (click.Option(["--an_option", ]), 0,
-         {'checked': '',
-          'click_type': 'text',
-          'desc': None,
-          'help': ('--an_option TEXT', ''),
-          'human_readable_name': 'an option',
-          'name': '0.0.option.text.1.text.--an-option',
-          'nargs': 1,
-          'param': 'option',
-          'required': False,
-          'type': 'text',
-          'value': ''}),
-        (click.Option(["--an_option", ], nargs=2), 1,
-         {'checked': '',
-          'click_type': 'text',
-          'desc': None,
-          'help': ('--an_option TEXT...', ''),
-          'human_readable_name': 'an option',
-          'name': '1.0.option.text.2.text.--an-option',
-          'nargs': 2,
-          'param': 'option',
-          'required': False,
-          'type': 'text',
-          'value': ''}),
-        (click.Option(["--flag/--no-flag", ], default=True, help='help'), 3,
-         {'checked': 'checked="checked"',
-          'click_type': 'bool_flag',
-          'desc': 'help',
-          'help': ('--flag / --no-flag', 'help'),
-          'human_readable_name': 'flag',
-          'name': '3.0.flag.bool_flag.1.checkbox.--flag',
-          'nargs': 1,
-          'off_flag': '--no-flag',
-          'on_flag': '--flag',
-          'param': 'option',
-          'required': False,
-          'type': 'checkbox',
-          'value': '--flag'}),
-    ])
+        (
+            click.Argument(
+                [
+                    "an_argument",
+                ]
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "text",
+                "help": "",
+                "human_readable_name": "AN ARGUMENT",
+                "name": "0.0.argument.text.1.text.an-argument",
+                "nargs": 1,
+                "param": "argument",
+                "required": True,
+                "type": "text",
+                "value": None,
+            },
+        ),
+        (
+            click.Argument(
+                [
+                    "an_argument",
+                ],
+                nargs=2,
+            ),
+            1,
+            {
+                "checked": "",
+                "click_type": "text",
+                "help": "",
+                "human_readable_name": "AN ARGUMENT",
+                "name": "1.0.argument.text.2.text.an-argument",
+                "nargs": 2,
+                "param": "argument",
+                "required": True,
+                "type": "text",
+                "value": None,
+            },
+        ),
+        (
+            click.Option(
+                [
+                    "--an_option",
+                ]
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "text",
+                "desc": None,
+                "help": ("--an_option TEXT", ""),
+                "human_readable_name": "an option",
+                "name": "0.0.option.text.1.text.--an-option",
+                "nargs": 1,
+                "param": "option",
+                "required": False,
+                "type": "text",
+                "value": "",
+            },
+        ),
+        (
+            click.Option(
+                [
+                    "--an_option",
+                ],
+                nargs=2,
+            ),
+            1,
+            {
+                "checked": "",
+                "click_type": "text",
+                "desc": None,
+                "help": ("--an_option TEXT...", ""),
+                "human_readable_name": "an option",
+                "name": "1.0.option.text.2.text.--an-option",
+                "nargs": 2,
+                "param": "option",
+                "required": False,
+                "type": "text",
+                "value": "",
+            },
+        ),
+        (
+            click.Option(
+                [
+                    "--flag/--no-flag",
+                ],
+                default=True,
+                help="help",
+            ),
+            3,
+            {
+                "checked": 'checked="checked"',
+                "click_type": "bool_flag",
+                "desc": "help",
+                "help": ("--flag / --no-flag", "help"),
+                "human_readable_name": "flag",
+                "name": "3.0.flag.bool_flag.1.checkbox.--flag",
+                "nargs": 1,
+                "off_flag": "--no-flag",
+                "on_flag": "--flag",
+                "param": "option",
+                "required": False,
+                "type": "checkbox",
+                "value": "--flag",
+            },
+        ),
+    ],
+)
 def test_get_input_field(ctx, click_cli, param, expected, command_index):
     res = input_fields.get_input_field(ctx, param, command_index, 0)
     pprint.pprint(res)
@@ -81,20 +131,31 @@ def test_get_input_field(ctx, click_cli, param, expected, command_index):
 
 
 @pytest.mark.parametrize(
-    'param, command_index, expected',
+    "param, command_index, expected",
     [
-        (click.Argument(["an_argument", ], nargs=-1), 0,
-         {'checked': '',
-          'click_type': 'text',
-          'help': '',
-          'human_readable_name': 'AN ARGUMENT',
-          'name': '0.0.argument.text.-1.text.an-argument',
-          'nargs': -1,
-          'param': 'argument',
-          'required': False,
-          'type': 'text',
-          'value': None}),
-    ])
+        (
+            click.Argument(
+                [
+                    "an_argument",
+                ],
+                nargs=-1,
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "text",
+                "help": "",
+                "human_readable_name": "AN ARGUMENT",
+                "name": "0.0.argument.text.-1.text.an-argument",
+                "nargs": -1,
+                "param": "argument",
+                "required": False,
+                "type": "text",
+                "value": None,
+            },
+        ),
+    ],
+)
 def test_variadic_arguments(ctx, click_cli, param, expected, command_index):
     res = input_fields.get_input_field(ctx, param, command_index, 0)
     pprint.pprint(res)
@@ -102,32 +163,53 @@ def test_variadic_arguments(ctx, click_cli, param, expected, command_index):
 
 
 @pytest.mark.parametrize(
-    'param, command_index, expected',
+    "param, command_index, expected",
     [
-        (click.Argument(["a_file_argument", ], type=click.File('rb')), 0,
-         {'checked': '',
-          'click_type': 'file[rb]',
-          'help': '',
-          'human_readable_name': 'A FILE ARGUMENT',
-          'name': '0.0.argument.file[rb].1.file.a-file-argument',
-          'nargs': 1,
-          'param': 'argument',
-          'required': True,
-          'type': 'file',
-          'value': None}),
-        (click.Option(["--a_file_option", ], type=click.File('rb')), 0,
-         {'checked': '',
-          'click_type': 'file[rb]',
-          'desc': None,
-          'help': ('--a_file_option FILENAME', ''),
-          'human_readable_name': 'a file option',
-          'name': '0.0.option.file[rb].1.file.--a-file-option',
-          'nargs': 1,
-          'param': 'option',
-          'required': False,
-          'type': 'file',
-          'value': ''}),
-    ])
+        (
+            click.Argument(
+                [
+                    "a_file_argument",
+                ],
+                type=click.File("rb"),
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "file[rb]",
+                "help": "",
+                "human_readable_name": "A FILE ARGUMENT",
+                "name": "0.0.argument.file[rb].1.file.a-file-argument",
+                "nargs": 1,
+                "param": "argument",
+                "required": True,
+                "type": "file",
+                "value": None,
+            },
+        ),
+        (
+            click.Option(
+                [
+                    "--a_file_option",
+                ],
+                type=click.File("rb"),
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "file[rb]",
+                "desc": None,
+                "help": ("--a_file_option FILENAME", ""),
+                "human_readable_name": "a file option",
+                "name": "0.0.option.file[rb].1.file.--a-file-option",
+                "nargs": 1,
+                "param": "option",
+                "required": False,
+                "type": "file",
+                "value": "",
+            },
+        ),
+    ],
+)
 def test_get_file_input_field(ctx, click_cli, param, expected, command_index):
     res = input_fields.get_input_field(ctx, param, command_index, 0)
     pprint.pprint(res)
@@ -135,32 +217,53 @@ def test_get_file_input_field(ctx, click_cli, param, expected, command_index):
 
 
 @pytest.mark.parametrize(
-    'param, command_index, expected',
+    "param, command_index, expected",
     [
-        (click.Argument(["a_file_argument", ], type=click.File('wb')), 0,
-         {'checked': '',
-          'click_type': 'file[wb]',
-          'help': '',
-          'human_readable_name': 'A FILE ARGUMENT',
-          'name': '0.0.argument.file[wb].1.hidden.a-file-argument',
-          'nargs': 1,
-          'param': 'argument',
-          'required': True,
-          'type': 'hidden',
-          'value': None}),
-        (click.Option(["--a_file_option", ], type=click.File('wb')), 0,
-         {'checked': '',
-          'click_type': 'file[wb]',
-          'desc': None,
-          'help': ('--a_file_option FILENAME', ''),
-          'human_readable_name': 'a file option',
-          'name': '0.0.option.file[wb].1.text.--a-file-option',
-          'nargs': 1,
-          'param': 'option',
-          'required': False,
-          'type': 'text',
-          'value': ''}),
-    ])
+        (
+            click.Argument(
+                [
+                    "a_file_argument",
+                ],
+                type=click.File("wb"),
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "file[wb]",
+                "help": "",
+                "human_readable_name": "A FILE ARGUMENT",
+                "name": "0.0.argument.file[wb].1.hidden.a-file-argument",
+                "nargs": 1,
+                "param": "argument",
+                "required": True,
+                "type": "hidden",
+                "value": None,
+            },
+        ),
+        (
+            click.Option(
+                [
+                    "--a_file_option",
+                ],
+                type=click.File("wb"),
+            ),
+            0,
+            {
+                "checked": "",
+                "click_type": "file[wb]",
+                "desc": None,
+                "help": ("--a_file_option FILENAME", ""),
+                "human_readable_name": "a file option",
+                "name": "0.0.option.file[wb].1.text.--a-file-option",
+                "nargs": 1,
+                "param": "option",
+                "required": False,
+                "type": "text",
+                "value": "",
+            },
+        ),
+    ],
+)
 def test_get_output_file_input_field(ctx, click_cli, param, expected, command_index):
     res = input_fields.get_input_field(ctx, param, command_index, 0)
     pprint.pprint(res)
@@ -168,25 +271,46 @@ def test_get_output_file_input_field(ctx, click_cli, param, expected, command_in
 
 
 @pytest.mark.parametrize(
-    'data, expected',
+    "data, expected",
     [
-        ({
-             '0.0.option.text.1.text.--an-option': 'option-value',
-             '0.1.option.text.1.text.--another-option': 'another-option-value',
-             '1.0.option.text.1.text.--option-for-other-command': 'some value'
-         }, (['--an-option', 'option-value', '--another-option', 'another-option-value'],
-             ['--option-for-other-command', 'some value']),
-        ), # noqa
-        (OrderedDict((
-                ('0.1.option.text.1.text.--another-option', 'another-option-value'),
-                ('0.0.option.text.1.text.--an-option', 'option-value'),
-                ('1.0.option.text.1.text.--option-for-other-command', 'some value')
-        )), (['--an-option', 'option-value', '--another-option', 'another-option-value'],
-             ['--option-for-other-command', 'some value']),
+        (
+            {
+                "0.0.option.text.1.text.--an-option": "option-value",
+                "0.1.option.text.1.text.--another-option": "another-option-value",
+                "1.0.option.text.1.text.--option-for-other-command": "some value",
+            },
+            (
+                [
+                    "--an-option",
+                    "option-value",
+                    "--another-option",
+                    "another-option-value",
+                ],
+                ["--option-for-other-command", "some value"],
+            ),
+        ),  # noqa
+        (
+            OrderedDict(
+                (
+                    ("0.1.option.text.1.text.--another-option", "another-option-value"),
+                    ("0.0.option.text.1.text.--an-option", "option-value"),
+                    ("1.0.option.text.1.text.--option-for-other-command", "some value"),
+                )
+            ),
+            (
+                [
+                    "--an-option",
+                    "option-value",
+                    "--another-option",
+                    "another-option-value",
+                ],
+                ["--option-for-other-command", "some value"],
+            ),
         ),
-    ])
+    ],
+)
 def test_form_post_to_commandline_arguments(data, expected, test_app):
-    with test_app.test_request_context(f'/command', data=data):
+    with test_app.test_request_context(f"/command", data=data):
         r = RequestToCommandArgs()
         for i, expect in enumerate(expected):
             assert r.command_args(i) == expected[i]

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -6,6 +6,7 @@ from tinydb import Query
 from archivy.helpers import get_db
 from archivy import data
 
+
 @pytest.fixture()
 def hooks_cli_runner(cli_runner, click_cli):
     """
@@ -33,11 +34,18 @@ def hooks_cli_runner(cli_runner, click_cli):
             f.write(dedent(hookfile))
         yield cli_runner
 
-def test_dataobj_creation_hook(test_app, hooks_cli_runner, note_fixture): 
-    creation_message = get_db().search(Query().type == "dataobj_creation_message")[0]
-    assert creation_message["content"] == f"New dataobj on {note_fixture.title} with tags: {note_fixture.tags}"
 
-def test_before_dataobj_creation_hook(test_app, hooks_cli_runner, note_fixture, bookmark_fixture):
+def test_dataobj_creation_hook(test_app, hooks_cli_runner, note_fixture):
+    creation_message = get_db().search(Query().type == "dataobj_creation_message")[0]
+    assert (
+        creation_message["content"]
+        == f"New dataobj on {note_fixture.title} with tags: {note_fixture.tags}"
+    )
+
+
+def test_before_dataobj_creation_hook(
+    test_app, hooks_cli_runner, note_fixture, bookmark_fixture
+):
     # check hook that added content at the end of body succeeded.
     message = "Dataobj made for test."
     assert message in note_fixture.content
@@ -45,10 +53,14 @@ def test_before_dataobj_creation_hook(test_app, hooks_cli_runner, note_fixture, 
 
 
 def test_dataobj_edit_hook(test_app, hooks_cli_runner, note_fixture, client):
-    client.put(f"/api/dataobjs/{note_fixture.id}", json={"content": "Updated note content"})
-    
+    client.put(
+        f"/api/dataobjs/{note_fixture.id}", json={"content": "Updated note content"}
+    )
+
     edit_message = get_db().search(Query().type == "edit_message")[0]
-    assert f"Changes made to content of {note_fixture.title}." == edit_message["content"]
+    assert (
+        f"Changes made to content of {note_fixture.title}." == edit_message["content"]
+    )
 
 
 def test_user_creation_hook(test_app, hooks_cli_runner, user_fixture):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -33,8 +33,7 @@ def test_new_note(test_app, note_fixture):
         assert getattr(note_fixture, attr) == saved_file[attr]
 
 
-def test_bookmark_sanitization(test_app, client, mocked_responses,
-                               bookmark_fixture):
+def test_bookmark_sanitization(test_app, client, mocked_responses, bookmark_fixture):
     """Test that bookmark content is correctly saved as correct Markdown"""
 
     with test_app.app_context():
@@ -43,11 +42,11 @@ def test_bookmark_sanitization(test_app, client, mocked_responses,
     saved_file = frontmatter.load(bookmark_fixture.fullpath)
     for attr in attributes:
         assert getattr(bookmark_fixture, attr) == saved_file[attr]
-    assert bookmark_fixture.url == saved_file["url"] 
+    assert bookmark_fixture.url == saved_file["url"]
 
     # remove buggy newlines that interfere with checks:
     bookmark_fixture.content = bookmark_fixture.content.replace("\n", "")
-    # test script is sanitized 
+    # test script is sanitized
     assert bookmark_fixture.content.find("<script>") == -1
     # test relative urls in the HTML are remapped to an absolute urls
     assert "example.com/images/image1.png" in bookmark_fixture.content
@@ -55,5 +54,3 @@ def test_bookmark_sanitization(test_app, client, mocked_responses,
 
     # check empty link has been cleared
     assert "[](empty-link)" not in bookmark_fixture.content
-
-


### PR DESCRIPTION
`flake8` is old and cumbersome, its painful, and a waste of time. The [PSF](https://en.wikipedia.org/wiki/Python_Software_Foundation) has created, and recommends new users to use the `black` code style, which is simple and ubobstrusive. 

The benefits of using `black` is that,
* it has an autolinter,
* It keeps a balance between readability and line limits
* The code looks exactly the same, despite how many times your run the linter on it. 

We can even attach a GitHub Action to automatically lint new user's pull requests, but I guess, I will leave that for discussion.
I have seen some projects adding `.git/hooks/pre-commit`, which runs the black linter before every commit. So all commits are neater than ever.


PS: the change from `'` to `"` is to signify i18n, as convention. `black` strictly enforces the same. 

Let me know your thoughts. I have migrated most of my projects to `black`.
