### PR TITLE
chore: update license, for 2021, and The Archivy Project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2020 Uzay-G
+Copyright (c) 2020-2021 Uzay-G
+Copyright (c) 2021 The Archivy Project, and Archivy contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
To also recognize the work done by archivy contributors under the same MIT License