### PR TITLE
Fix possible removal of directories with path traversal

### DIFF
--- a/archivy/api.py
+++ b/archivy/api.py
@@ -155,10 +155,11 @@ def create_folder():
     directory = request.json.get("path")
     try:
         sanitized_name = data.create_dir(directory)
+        print(sanitized_name)
         if not sanitized_name:
-            return Response("Invalid dirname", satus=401)
+            return Response("Invalid dirname", status=400)
     except FileExistsError:
-        return Response("Directory already exists", status=401)
+        return Response("Directory already exists", status=400)
     return Response(sanitized_name, status=200)
 
 
@@ -175,7 +176,7 @@ def delete_folder():
         return Response("Cannot delete root dir", status=401)
     if data.delete_dir(directory):
         return Response("Successfully deleted", status=200)
-    return Response("Could not delete directory", status=404)
+    return Response("Could not delete directory", status=400)
 
 
 @api_bp.route("/search", methods=["GET"])

--- a/archivy/api.py
+++ b/archivy/api.py
@@ -155,6 +155,8 @@ def create_folder():
     directory = request.json.get("path")
     try:
         sanitized_name = data.create_dir(directory)
+        if not sanitized_name:
+            return Response("Invalid dirname", satus=401)
     except FileExistsError:
         return Response("Directory already exists", status=401)
     return Response(sanitized_name, status=200)
@@ -173,7 +175,7 @@ def delete_folder():
         return Response("Cannot delete root dir", status=401)
     if data.delete_dir(directory):
         return Response("Successfully deleted", status=200)
-    return Response("Not found", status=404)
+    return Response("Could not delete directory", status=404)
 
 
 @api_bp.route("/search", methods=["GET"])

--- a/archivy/data.py
+++ b/archivy/data.py
@@ -17,6 +17,17 @@ def get_data_dir():
     """Returns the directory where dataobjs are stored"""
     return Path(current_app.config['USER_DIR']) / "data"
 
+def is_relative_to(a, b):
+    try:
+        a.relative_to(b)
+        return True
+    except ValueError:
+        return False
+
+def is_sub_datadir(path: Path):
+    #Not implemented in python < 3.8 
+    #return path.resolve().is_relative_to(get_data_dir().resolve())
+    return is_relative_to(path.resolve(), get_data_dir().resolve())
 
 class Directory:
     """Tree like file-structure used to build file navigation in Archiv"""
@@ -195,8 +206,11 @@ def create_dir(name):
 
 def delete_dir(name):
     """Deletes dir of given name"""
+    delete_dir = get_data_dir() / name
+    if not is_sub_datadir(delete_dir):
+        return False
     try:
-        rmtree(get_data_dir() / name.strip("/"))
+        rmtree(delete_dir)
         return True
     except FileNotFoundError:
         return False

--- a/archivy/data.py
+++ b/archivy/data.py
@@ -18,6 +18,15 @@ def get_data_dir():
     return Path(current_app.config['USER_DIR']) / "data"
 
 
+def is_relative_to(sub_path, parent):
+    """Implement pathlib `is_relative_to` only available in python 3.9"""
+    try:
+        sub_path.resolve().relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
 class Directory:
     """Tree like file-structure used to build file navigation in Archiv"""
     def __init__(self, name):
@@ -51,7 +60,7 @@ def get_items(collections=[], path="", structured=True, json_format=False):
     datacont = Directory(path or "root") if structured else []
     data_dir = get_data_dir()
     root_dir = data_dir / path
-    if not root_dir.resolve().is_relative_to(data_dir) or not root_dir.exists():
+    if not is_relative_to(root_dir, data_dir) or not root_dir.exists():
         raise FileNotFoundError
     if structured:
         for filepath in root_dir.rglob("*"):
@@ -190,7 +199,7 @@ def create_dir(name):
     """Create dir of given name"""
     root_dir = get_data_dir()
     new_path = root_dir / name.strip("/")
-    if new_path.resolve().is_relative_to(root_dir):
+    if is_relative_to(new_path, root_dir):
         new_path.mkdir(parents=True, exist_ok=True)
         return str(new_path.relative_to(root_dir))
     return False
@@ -199,11 +208,11 @@ def create_dir(name):
 def delete_dir(name):
     """Deletes dir of given name"""
     root_dir = get_data_dir()
-    delete_dir = root_dir / name
-    if not delete_dir.resolve().is_relative_to(root_dir) or delete_dir == root_dir:
+    target_dir = root_dir / name
+    if not is_relative_to(target_dir, root_dir) or target_dir == root_dir:
         return False
     try:
-        rmtree(delete_dir)
+        rmtree(target_dir)
         return True
     except FileNotFoundError:
         return False

--- a/archivy/data.py
+++ b/archivy/data.py
@@ -51,7 +51,7 @@ def get_items(collections=[], path="", structured=True, json_format=False):
     datacont = Directory(path or "root") if structured else []
     data_dir = get_data_dir()
     root_dir = data_dir / path
-    if not root_dir.is_relative_to(data_dir) or not root_dir.exists():
+    if not root_dir.resolve().is_relative_to(data_dir) or not root_dir.exists():
         raise FileNotFoundError
     if structured:
         for filepath in root_dir.rglob("*"):
@@ -190,7 +190,7 @@ def create_dir(name):
     """Create dir of given name"""
     root_dir = get_data_dir()
     new_path = root_dir / name.strip("/")
-    if new_path.is_relative_to(root_dir):
+    if new_path.resolve().is_relative_to(root_dir):
         new_path.mkdir(parents=True, exist_ok=True)
         return str(new_path.relative_to(root_dir))
     return False
@@ -200,7 +200,7 @@ def delete_dir(name):
     """Deletes dir of given name"""
     root_dir = get_data_dir()
     delete_dir = root_dir / name
-    if not delete_dir.is_relative_to(root_dir) or delete_dir == root_dir:
+    if not delete_dir.resolve().is_relative_to(root_dir) or delete_dir == root_dir:
         return False
     try:
         rmtree(delete_dir)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -126,3 +126,13 @@ def test_unlogged_in_api_fails(test_app, client: FlaskClient):
     resp = client.get("/api/dataobjs")
     assert resp.status_code == 302
 
+
+def test_deleting_unrelated_user_dir_fails(test_app, client: FlaskClient):
+    resp = client.delete("/api/folders/delete", json={"path": "/dev/null"})
+    assert resp.status_code == 400
+
+
+
+def test_path_injection_fails(test_app, client: FlaskClient):
+    resp = client.post("/api/folders/new", json={"path": "../../"})
+    assert resp.status_code == 400


### PR DESCRIPTION
At the moment it is still possible to delete directories using relatives path. For example sending a request with the path `../../../../../../../../bin` would delete the /bin folder if you have the permission