### PR TITLE
Improvements to image upload

### DIFF
--- a/archivy/config.py
+++ b/archivy/config.py
@@ -14,7 +14,7 @@ class Config(object):
         os.makedirs(self.INTERNAL_DIR, exist_ok=True)
 
         self.PANDOC_HIGHLIGHT_THEME = "pygments"
-
+        self.SCRAPING_CONF = {"save_images": False}
         self.SEARCH_CONF = {
             "enabled": 0,
             "url": "http://localhost:9200",

--- a/archivy/data.py
+++ b/archivy/data.py
@@ -7,6 +7,7 @@ from shutil import rmtree
 import frontmatter
 from flask import current_app
 from werkzeug.utils import secure_filename
+from werkzeug.datastructures import FileStorage
 
 from archivy.helpers import load_hooks
 from archivy.search import remove_from_index
@@ -326,7 +327,7 @@ def valid_image_filename(filename):
     return "." in filename and filename.rsplit(".")[1] in ALLOWED_EXTENSIONS
 
 
-def save_image(image):
+def save_image(image: FileStorage):
     """
     Saves image to USER_DATA_DIR
 

--- a/archivy/models.py
+++ b/archivy/models.py
@@ -148,10 +148,7 @@ class DataObj:
             elif (
                 tag.name == "img"
                 and tag.has_attr("src")
-                and (tag["src"].startswith("/") or tag["src"].startswith("./"))
             ):
-
-                tag["src"] = urljoin(url, tag["src"])
                 filename = tag["src"].split("/")[-1]
                 try:
                     filename = filename[
@@ -159,6 +156,8 @@ class DataObj:
                     ]  # remove query parameters
                 except ValueError:
                     pass
+                if tag["src"].startswith("/") or tag["src"].startswith("./"):
+                    tag["src"] = urljoin(url, tag["src"])
                 if current_app.config["SCRAPING_CONF"][
                     "save_images"
                 ] and valid_image_filename(filename):

--- a/archivy/models.py
+++ b/archivy/models.py
@@ -145,10 +145,7 @@ class DataObj:
                     # delete tag
                     tag.decompose()
 
-            elif (
-                tag.name == "img"
-                and tag.has_attr("src")
-            ):
+            elif tag.name == "img" and tag.has_attr("src"):
                 filename = tag["src"].split("/")[-1]
                 try:
                     filename = filename[

--- a/archivy/models.py
+++ b/archivy/models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pkg_resources import require
 from typing import List, Optional
 from urllib.parse import urljoin
+from io import BytesIO
 
 import frontmatter
 import requests
@@ -9,14 +10,15 @@ import validators
 from attr import attrs, attrib
 from attr.validators import instance_of, optional
 from bs4 import BeautifulSoup
-from flask import flash
+from flask import flash, current_app
 from flask_login import UserMixin
 from html2text import html2text
 from tinydb import Query
 from werkzeug.security import generate_password_hash
+from werkzeug.datastructures import FileStorage
 
 from archivy import helpers
-from archivy.data import create
+from archivy.data import create, save_image, valid_image_filename
 from archivy.search import add_to_index
 
 
@@ -123,7 +125,7 @@ class DataObj:
         self.content = ""
 
     def extract_content(self, beautsoup):
-        """converts html bookmark url to optimized markdown"""
+        """converts html bookmark url to optimized markdown and saves images"""
 
         stripped_tags = ["footer", "nav"]
         url = self.url.rstrip("/")
@@ -150,6 +152,21 @@ class DataObj:
             ):
 
                 tag["src"] = urljoin(url, tag["src"])
+                filename = tag["src"].split("/")[-1]
+                try:
+                    filename = filename[
+                        : filename.index("?")
+                    ]  # remove query parameters
+                except ValueError:
+                    pass
+                if current_app.config["SCRAPING_CONF"][
+                    "save_images"
+                ] and valid_image_filename(filename):
+                    image = FileStorage(
+                        BytesIO(requests.get(tag["src"]).content), filename, name="file"
+                    )
+                    saved_to = save_image(image)
+                    tag["src"] = "/images/" + saved_to
 
         res = html2text(str(beautsoup), bodywidth=0)
         return res

--- a/docs/config.md
+++ b/docs/config.md
@@ -14,6 +14,14 @@ Here's an overview of the different values you can set and modify.
 | `PORT`          | 5000                        | Port on which archivy will run        |
 | `HOST`          | 127.0.0.1                   | Host on which the app will run. |
 
+### Scraping
+
+An in-progress configuration object to customize how you'd like bookmarking / scraping to work.
+
+| Variable                | Default                     | Description                           |
+|-------------------------|-----------------------------|---------------------------------------|
+| `save_images` | False | If true, whenever you save a bookmark, every linked image will also be downloaded locally. | 
+
 
 ### Search
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -61,8 +61,12 @@ def test_bookmark_sanitization(test_app, client, mocked_responses, bookmark_fixt
 
 
 def test_bookmark_included_images_are_saved(test_app, client, mocked_responses):
-    mocked_responses.add(GET, "https://example.com", body="""<html><img src='/image.png'></html>""")
-    mocked_responses.add(GET, "https://example.com/image.png", body=open("docs/img/logo.png", "rb"))
+    mocked_responses.add(
+        GET, "https://example.com", body="""<html><img src='/image.png'></html>"""
+    )
+    mocked_responses.add(
+        GET, "https://example.com/image.png", body=open("docs/img/logo.png", "rb")
+    )
     test_app.config["SCRAPING_CONF"]["save_images"] = True
     bookmark = DataObj(type="bookmark", url="https://example.com")
     bookmark.process_bookmark_url()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 import frontmatter
 
 from archivy.models import DataObj
 from archivy.helpers import get_max_id
+from responses import RequestsMock, GET
+
 from archivy.models import DataObj
 
 attributes = ["type", "title", "tags", "path", "id"]
@@ -54,3 +58,15 @@ def test_bookmark_sanitization(test_app, client, mocked_responses, bookmark_fixt
 
     # check empty link has been cleared
     assert "[](empty-link)" not in bookmark_fixture.content
+
+
+def test_bookmark_included_images_are_saved(test_app, client, mocked_responses):
+    mocked_responses.add(GET, "https://example.com", body="""<html><img src='/image.png'></html>""")
+    mocked_responses.add(GET, "https://example.com/image.png", body=open("docs/img/logo.png", "rb"))
+    test_app.config["SCRAPING_CONF"]["save_images"] = True
+    bookmark = DataObj(type="bookmark", url="https://example.com")
+    bookmark.process_bookmark_url()
+    bookmark.insert()
+    images_dir = Path(test_app.config["USER_DIR"]) / "images"
+    assert images_dir.exists()
+    assert (images_dir / "image.png").exists()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -4,7 +4,7 @@ import frontmatter
 
 from archivy.models import DataObj
 from archivy.helpers import get_max_id
-from responses import RequestsMock, GET
+from responses import GET
 
 from archivy.models import DataObj
 


### PR DESCRIPTION
This implements a new config option, inside `SCRAPING_CONF["save_images"]` where images called in downloaded webpages are stored locally. I decided to set this to False by default.