### PR TITLE
Editor improvements to save bookmark from editor + new DEFAULT_BOOKMARKS_DIR option

### DIFF
--- a/archivy/api.py
+++ b/archivy/api.py
@@ -46,7 +46,7 @@ def create_bookmark():
     json_data = request.get_json()
     bookmark = DataObj(
         url=json_data["url"],
-        tags=json_data.get("tags"),
+        tags=json_data.get("tags", []),
         path=json_data.get("path", ""),
         type="bookmark",
     )

--- a/archivy/api.py
+++ b/archivy/api.py
@@ -1,4 +1,4 @@
-from flask import Response, jsonify, request, Blueprint
+from flask import Response, jsonify, request, Blueprint, current_app
 from werkzeug.security import check_password_hash
 from flask_login import login_user
 from tinydb import Query
@@ -47,7 +47,7 @@ def create_bookmark():
     bookmark = DataObj(
         url=json_data["url"],
         tags=json_data.get("tags", []),
-        path=json_data.get("path", ""),
+        path=json_data.get("path", current_app.config["DEFAULT_BOOKMARKS_DIR"]),
         type="bookmark",
     )
     bookmark.process_bookmark_url()

--- a/archivy/config.py
+++ b/archivy/config.py
@@ -11,7 +11,7 @@ class Config(object):
         self.HOST = "127.0.0.1"
         self.INTERNAL_DIR = appdirs.user_data_dir("archivy")
         self.USER_DIR = self.INTERNAL_DIR
-        self.DEFAULT_BOOKMARKS_DIR = "not classified"
+        self.DEFAULT_BOOKMARKS_DIR = ""
         os.makedirs(self.INTERNAL_DIR, exist_ok=True)
 
         self.PANDOC_HIGHLIGHT_THEME = "pygments"

--- a/archivy/config.py
+++ b/archivy/config.py
@@ -11,6 +11,7 @@ class Config(object):
         self.HOST = "127.0.0.1"
         self.INTERNAL_DIR = appdirs.user_data_dir("archivy")
         self.USER_DIR = self.INTERNAL_DIR
+        self.DEFAULT_BOOKMARKS_DIR = "not classified"
         os.makedirs(self.INTERNAL_DIR, exist_ok=True)
 
         self.PANDOC_HIGHLIGHT_THEME = "pygments"

--- a/archivy/routes.py
+++ b/archivy/routes.py
@@ -61,7 +61,7 @@ def index():
 # TODO: refactor two following methods
 @app.route("/bookmarks/new", methods=["GET", "POST"])
 def new_bookmark():
-    bookmark_dir = app.config["DEFAULT_BOOKMARKS_DIR"]
+    bookmark_dir = app.config["DEFAULT_BOOKMARKS_DIR"] or "not classified"
     form = forms.NewBookmarkForm(path=bookmark_dir)
     form.path.choices = [(pathname, pathname) for pathname in data.get_dirs()]
     if form.validate_on_submit():

--- a/archivy/routes.py
+++ b/archivy/routes.py
@@ -61,7 +61,8 @@ def index():
 # TODO: refactor two following methods
 @app.route("/bookmarks/new", methods=["GET", "POST"])
 def new_bookmark():
-    form = forms.NewBookmarkForm()
+    bookmark_dir = app.config["DEFAULT_BOOKMARKS_DIR"]
+    form = forms.NewBookmarkForm(path=bookmark_dir)
     form.path.choices = [(pathname, pathname) for pathname in data.get_dirs()]
     if form.validate_on_submit():
         path = form.path.data if form.path.data != "not classified" else ""
@@ -74,9 +75,9 @@ def new_bookmark():
             return redirect(f"/dataobj/{bookmark_id}")
     # for bookmarklet
     form.url.data = request.args.get("url", "")
-    path = request.args.get("path", "not classified").strip("/")
+    path = request.args.get("path", bookmark_dir).strip("/")
     # handle empty argument
-    form.path.data = path if path != "" else "not classified"
+    form.path.data = path or bookmark_dir
     return render_template("dataobjs/new.html", title="New Bookmark", form=form)
 
 

--- a/archivy/routes.py
+++ b/archivy/routes.py
@@ -81,7 +81,7 @@ def new_bookmark():
     form.url.data = request.args.get("url", "")
     path = request.args.get("path", default_dir).strip("/")
     # handle empty argument
-    form.path.data = path or bookmark_dir
+    form.path.data = path
     return render_template("dataobjs/new.html", title="New Bookmark", form=form)
 
 

--- a/archivy/templates/dataobjs/show.html
+++ b/archivy/templates/dataobjs/show.html
@@ -139,9 +139,9 @@
                   "side-by-side",
                   "fullscreen",
                   {
-                    name: "bookmarks",
+                    name: "local-archive-btn",
                     className: "fa fa-bookmark",
-                    title: "Download a webpage into archivy and link to it",
+                    title: "Archives and links to local copy of selected url",
                     action: async editor => {
                       let link = editor.codemirror.getSelection().trim(), url;
                       try {
@@ -180,7 +180,7 @@
                   {% endif %}
                   {
                     name: "save",
-                    title: "Save note contents"
+                    title: "Save note contents",
                     action: (editor) => {
                       fetch(`${SCRIPT_ROOT}/dataobjs/{{dataobj['id']}}`, {
                         method: "PUT",

--- a/archivy/templates/dataobjs/show.html
+++ b/archivy/templates/dataobjs/show.html
@@ -131,6 +131,7 @@
                   {
                     name: "LaTeX",
                     className: "fa fa-math",
+                    title: "Embed Maths",
                     action: (editor) => {
                       editor.codemirror.replaceSelection("$$\n$$")
                     }
@@ -138,7 +139,48 @@
                   "side-by-side",
                   "fullscreen",
                   {
+                    name: "bookmarks",
+                    className: "fa fa-bookmark",
+                    title: "Download a webpage into archivy and link to it",
+                    action: async editor => {
+                      let link = editor.codemirror.getSelection().trim(), url;
+                      try {
+                        url = new URL(link);
+                      }
+                      catch (_) {
+                        return false;
+                      }
+                      if (url.protocol !== "http:" && url.protocol !== "https:") {
+                        return false;
+                      }
+                      let req = await fetch(`${SCRIPT_ROOT}/bookmarks`, {
+                        method: "POST",
+                        body: JSON.stringify({
+                          "url": link
+                        }),
+                        headers: {
+                          "content-type": "application/json"
+                        }
+                      })
+                      if (req.ok) {
+                        let bookmark = await req.json();
+                        editor.codemirror.replaceSelection(`[${link}](/dataobj/${bookmark["bookmark_id"]})\n`); 
+                      }
+                    }
+                  },
+
+                  {% if search_enabled %}
+	            {
+		      name: "bidirBtn",
+		      action: (editor) => {
+		        toggleLinkForm();
+		      },
+		      className: "fa fa-arrow-alt-h"
+		    },
+                  {% endif %}
+                  {
                     name: "save",
+                    title: "Save note contents"
                     action: (editor) => {
                       fetch(`${SCRIPT_ROOT}/dataobjs/{{dataobj['id']}}`, {
                         method: "PUT",
@@ -155,19 +197,16 @@
                     },
                     className: "fa fa-save"
                   },
-                  {% if search_enabled %}
-	            {
-		      name: "bidirBtn",
-		      action: (editor) => {
-		        toggleLinkForm();
-		      },
-		      className: "fa fa-arrow-alt-h"
-		    },
-                  {% endif %}
                   {
                     name: "status",
                     className: "fa fa-check-circle status"
                   },
+                  {
+                    name: "doc",
+                    className: "fa fa-question-circle",
+                    action: "https://archivy.github.io/editing",
+                    title: "Editing Guide"
+                  }
                 ],
                 shortcuts: {
                   "save": "Ctrl-S"

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,6 +13,7 @@ Here's an overview of the different values you can set and modify.
 | `INTERNAL_DIR` | System-dependent, see below | Directory where archivy internals will be stored (config, db...)
 | `PORT`          | 5000                        | Port on which archivy will run        |
 | `HOST`          | 127.0.0.1                   | Host on which the app will run. |
+| `DEFAULT_BOOKMARKS_DIR` | empty string (represents the root directory) | any subdirectory of the `data/` directory with your notes.
 
 
 ### Search

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -6,6 +6,8 @@ We've also included a few powerful extensions:
 
 - **Bidirectional links**: You can create a link to a note by clicking the "Link to a note" button. All links to a given note will be displayed when you visit that note, at the bottom in the "Backlinks" section.
 
+- **In-editor bookmarking**: if you'd like to store a local copy of a webpage you're referring to inside an archivy note, simply select the url and click the "bookmark" icon.
+
 - **LaTeX**: you can render mathematical expressions like this:
 
 ```md
@@ -40,11 +42,9 @@ There are several ways you can edit content in Archivy.
 
 Whenever you open a note or bookmark, at the bottom of the page you'll find a few buttons that allow you to edit it.
 
-## Ways you can edit
+## Editing through the web interface
 
-## Through the web interface
-
-You can still do edits through the web app, by clicking "Toggle web editor" at the bottom.
+You can edit through the web app, by clicking "Toggle web editor" at the bottom. This is the recommended way because the Archivy web editor provides useful functionality. You can save your work, link to other notes with the "Link to a note button", and archive webpages referenced in your note, all inside the editor!
 
 ## Locally
 

--- a/tests/functional/test_routes.py
+++ b/tests/functional/test_routes.py
@@ -7,7 +7,7 @@ from responses import RequestsMock, GET
 from werkzeug.security import generate_password_hash
 
 from archivy.helpers import get_max_id, get_db
-from archivy.data import get_dirs, create_dir, get_items, get_ite 
+from archivy.data import get_dirs, create_dir, get_items, get_item
 
 
 def test_get_index(test_app, client: FlaskClient):

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -4,7 +4,7 @@ from os import remove
 import responses
 from flask import Flask
 from flask.testing import FlaskClient
-from archivy.data import create_dir, get_items
+from archivy.data import create_dir, get_items, create_dir
 from archivy.models import DataObj
 
 
@@ -38,6 +38,25 @@ def test_create_bookmark(test_app, client: FlaskClient, mocked_responses):
     assert response.json["title"] == "http://example.org"
     assert response.json["dataobj_id"] == 1
     assert response.json["content"] == "Example"
+
+
+def test_creating_bookmark_without_passing_path_saves_to_default_dir(
+    test_app, client, mocked_responses
+):
+    mocked_responses.add(responses.GET, "http://example.org", body="Example\n")
+    bookmarks_dir = "bookmarks"
+    test_app.config["DEFAULT_BOOKMARKS_DIR"] = bookmarks_dir
+    create_dir(bookmarks_dir)
+    resp = client.post(
+        "/api/bookmarks",
+        json={
+            "url": "http://example.org",
+        },
+    )
+    bookmark = get_items(structured=False)[0]
+    assert (
+        "bookmarks" in bookmark["path"]
+    )  # verify it was saved to default bookmark dir
 
 
 def test_create_note(test_app, client: FlaskClient, mocked_responses):


### PR DESCRIPTION
Adds two related imrpovements:

- a new "bookmark" icon is available which allows you to scrape a url you've selected with your cursor and replace it with a locally archived version.
- You can configure a default bookmarks dir to save bookmarks if the `path` is omitted, instead of having them encumber your root dir.

