### PR TITLE
Allow override of "Archivy" for site title and page headings

### DIFF
--- a/archivy/config.py
+++ b/archivy/config.py
@@ -12,6 +12,7 @@ class Config(object):
         self.INTERNAL_DIR = appdirs.user_data_dir("archivy")
         self.USER_DIR = self.INTERNAL_DIR
         self.DEFAULT_BOOKMARKS_DIR = ""
+        self.SITE_TITLE = "Archivy"
         os.makedirs(self.INTERNAL_DIR, exist_ok=True)
 
         self.PANDOC_HIGHLIGHT_THEME = "pygments"

--- a/archivy/templates/base.html
+++ b/archivy/templates/base.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-      <title>{{ title }} - Archivy</title>
+      <title>{{ title }} - {{ config.SITE_TITLE }}</title>
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}">
@@ -58,7 +58,7 @@
             <div class="Header-item full">
                 <a class="Header-link" href="/">
                     <img src="https://archivy.github.io/img/logo-2.png" alt="archivy logo" width="35" height="35">
-                    <h3>Archivy</h3>
+                    <h3>{{ config.SITE_TITLE }}</h3>
                 </a>
             </div>
 

--- a/archivy/templates/bookmarklet.html
+++ b/archivy/templates/bookmarklet.html
@@ -7,6 +7,6 @@ Using the bookmarklet allows you to quickly add bookmarks to archivy.
 
 All you need to do is drage the link below to your browser toolbar. Then, when you find an interesting link, just click the button on your toolbar named "Add to archivy".
 
-<h3><a href="javascript:window.location = `{{ request.host_url | safe  }}bookmarks/new?url=${window.location}`;">Add to Archivy</a></h3>
+<h3><a href="javascript:window.location = `{{ request.host_url | safe  }}bookmarks/new?url=${window.location}`;">Add to {{ config.SITE_TITLE }}</a></h3>
 
 {% endblock %}

--- a/archivy/templates/dataobjs/new.html
+++ b/archivy/templates/dataobjs/new.html
@@ -1,4 +1,3 @@
-
 {% extends "base.html" %}
 
 {% block content %}

--- a/archivy/templates/users/edit.html
+++ b/archivy/templates/users/edit.html
@@ -1,4 +1,3 @@
-
 {% extends "base.html" %}
 {% block content %}
 <br>

--- a/archivy/templates/users/login.html
+++ b/archivy/templates/users/login.html
@@ -4,7 +4,7 @@
 <div id="login-cont">
     <img src="https://archivy.github.io/img/logo-2.png" width="100" height="100">
     <form action="" method="post">
-        <h1>Sign in with {{ config.SITE_TITLE }}</h1>
+        <h1>Sign in</h1>
         {{ form.hidden_tag() }}
         {% for error in form.username.errors %}
             <div class="flash flash-error">{{ error }}</div>

--- a/archivy/templates/users/login.html
+++ b/archivy/templates/users/login.html
@@ -4,7 +4,7 @@
 <div id="login-cont">
     <img src="https://archivy.github.io/img/logo-2.png" width="100" height="100">
     <form action="" method="post">
-        <h1>Sign in with Archivy</h1>
+        <h1>Sign in with {{ config.SITE_TITLE }}</h1>
         {{ form.hidden_tag() }}
         {% for error in form.username.errors %}
             <div class="flash flash-error">{{ error }}</div>

--- a/docs/config.md
+++ b/docs/config.md
@@ -10,10 +10,11 @@ Here's an overview of the different values you can set and modify.
 | Variable                | Default                     | Description                           |
 |-------------------------|-----------------------------|---------------------------------------|
 | `USER_DIR`      | System-dependent, see below. It is recommended to set this through `archivy init` | Directory in which markdown data will be saved |
-| `INTERNAL_DIR` | System-dependent, see below | Directory where archivy internals will be stored (config, db...)
+| `INTERNAL_DIR`  | System-dependent, see below | Directory where archivy internals will be stored (config, db...)
 | `PORT`          | 5000                        | Port on which archivy will run        |
 | `HOST`          | 127.0.0.1                   | Host on which the app will run. |
 | `DEFAULT_BOOKMARKS_DIR` | empty string (represents the root directory) | any subdirectory of the `data/` directory with your notes.
+| `SITE_TITLE`    | Archivy                     | String value to be displayed in page title and headings. |
 
 ### Scraping
 
@@ -27,7 +28,7 @@ SCRAPING_CONF:
 
 | Variable                | Default                     | Description                           |
 |-------------------------|-----------------------------|---------------------------------------|
-| `save_images` | False | If true, whenever you save a bookmark, every linked image will also be downloaded locally. | 
+| `save_images` | False | If true, whenever you save a bookmark, every linked image will also be downloaded locally. |
 
 ### Theming
 


### PR DESCRIPTION
Allow a user to override the normal application page title and headers via a configuration variable. Summary of changes:

- added SITE_TITLE config variable with default "Archivy"
- render SITE_TITLE in templates
- described SITE_TITLE in docs/config.md

Note that the default value for SITE_TITLE is included in the `config.yml` generated by the `archivy init` CLI command, and no changes have been made to allow users to set the value interactively via this command (possible future improvement).