### PR TITLE
Disable spell check

### DIFF
--- a/archivy/config.py
+++ b/archivy/config.py
@@ -41,6 +41,7 @@ class Config(object):
                 "markdownItAnchor": {"permalink": True, "permalinkSymbol": "¶"},
                 "markdownItTocDoneRight": {},
             },
+            "spellcheck": False,
         }
 
         self.SEARCH_CONF = {

--- a/archivy/templates/dataobjs/show.html
+++ b/archivy/templates/dataobjs/show.html
@@ -289,6 +289,7 @@
         });  // EasyMDE
 
         editor.value(content)
+        editor.codemirror.setOption('mode', 'markdown');
 
         let statusBtn = document.querySelector(".status .fa");
         editor.codemirror.on("change", function() {

--- a/archivy/templates/dataobjs/show.html
+++ b/archivy/templates/dataobjs/show.html
@@ -289,7 +289,11 @@
         });  // EasyMDE
 
         editor.value(content)
-        editor.codemirror.setOption('mode', 'markdown');
+        {% if config.EDITOR_CONF.get('spellcheck', True) %}
+          // Spellcheck is on by default
+        {% else %}
+          editor.codemirror.setOption('mode', 'markdown');
+        {% endif %}
 
         let statusBtn = document.querySelector(".status .fa");
         editor.codemirror.on("change", function() {


### PR DESCRIPTION
If you don't mind, I'd like to disable spell-check.

Right now, we have the editor configuration that is actually a markdown-parser configuration. We could incorporate this change into a new config object that goes
```
rendering = {
  "markdown-parser": what-we-already-have,
  "editor": things like this
}
```

Sorry for the git hick-up 