### PR TITLE
Add helper command to generate plugin directory with structure

### DIFF
--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -10,7 +10,7 @@ from archivy import app
 from archivy.config import Config
 from archivy.click_web import create_click_web_app
 from archivy.data import open_file, format_file, unformat_file
-from archivy.helpers import load_config, write_config
+from archivy.helpers import load_config, write_config, create_directory
 from archivy.models import User, DataObj
 
 
@@ -165,6 +165,14 @@ def index():
             click.echo(f"Indexed {dataobj.title}...")
         else:
             click.echo(f"Failed to index {dataobj.title}")
+
+@cli.command(short_help="Helper command to auto-generate plugin directory with structure")
+@click.argument("name")
+def plugin_new(name):
+    if create_directory(name):
+        click.echo(f"Successfully Created the plugin directory structure with name 'archivy_{name}'.")
+    else:
+        click.echo(f"Directory with name '{name}' already exists.")
 
 
 if __name__ == "__main__":

--- a/archivy/cli.py
+++ b/archivy/cli.py
@@ -10,7 +10,7 @@ from archivy import app
 from archivy.config import Config
 from archivy.click_web import create_click_web_app
 from archivy.data import open_file, format_file, unformat_file
-from archivy.helpers import load_config, write_config, create_directory
+from archivy.helpers import load_config, write_config, create_plugin_dir
 from archivy.models import User, DataObj
 
 
@@ -166,11 +166,14 @@ def index():
         else:
             click.echo(f"Failed to index {dataobj.title}")
 
-@cli.command(short_help="Helper command to auto-generate plugin directory with structure")
+
+@cli.command(
+    short_help="Helper command to auto-generate plugin directory with structure"
+)
 @click.argument("name")
 def plugin_new(name):
-    if create_directory(name):
-        click.echo(f"Successfully Created the plugin directory structure with name 'archivy_{name}'.")
+    if create_plugin_dir(name):
+        click.echo(f"Successfully Created the plugin directory structure at '{name}'/.")
     else:
         click.echo(f"Directory with name '{name}' already exists.")
 

--- a/archivy/helpers.py
+++ b/archivy/helpers.py
@@ -160,70 +160,72 @@ def get_elastic_client(error_if_invalid=True):
     return es
 
 
-def create_directory(name):
-    """Creates a directory structure where one can make plugins
-
-    Args:
-        name: Name of the plugin.
-
-    Returns:
-        bool: True if successfully created else False
-
-    """
+def create_plugin_dir(name):
+    """Creates a sample plugin directory"""
+    raw_name = name.replace("archivy_", "").replace("archivy-", "")
     try:
-        os.makedirs(f"archivy_{name}/archivy_{name}")
+        os.makedirs(f"{name}/{name}")
 
         # Creates requirements.txt.
-        with open(f"archivy_{name}/requirements.txt", "w") as fp:
-            fp.writelines(["archivy", "\ntinydb", "\nclick", "\nrequests"])
+        with open(f"{name}/requirements.txt", "w") as fp:
+            fp.writelines(["archivy", "\nclick"])
 
         # Creates an empty readme file to be filled
-        with open(f"archivy_{name}/README.md", "w+") as fp:
-            fp.writelines(['<!-- Plugin Description -->',
-                           '\n\n## Install',
-                           '\n\nYou need to have `archivy` already installed.',
-                           f'\n\nRun `pip install archivy_{name}`',
-                           '\n\n## Usage'])
+        with open(f"{name}/README.md", "w+") as fp:
+            fp.writelines(
+                [
+                    f"# {name}",
+                    "\n\n## Install",
+                    "\n\nYou need to have `archivy` already installed.",
+                    f"\n\nRun `pip install archivy_{name}`",
+                    "\n\n## Usage",
+                ]
+            )
 
         # Creates a setup.py file
-        with open(f"archivy_{name}/setup.py", "w") as setup_f:
-            setup_f.writelines(["from setuptools import setup, find_packages",
-                                '\n\nwith open("README.md", "r") as fh:',
-                                '\n\tlong_description = fh.read()',
-                                '\n\nwith open("requirements.txt", encoding="utf-8") as f:',
-                                '\n\tall_reqs = f.read().split("\\n")',
-                                '\n\tinstall_requires = [x.strip() for x in all_reqs]',
-                                '\n\n#Fill in the details below for distribution purposes'
-                                f'\nsetup(\n\tname="archivy_{name}",',
-                                '\n\tversion="0.0.1",',
-                                '\n\tauthor="",',
-                                '\n\tauthor_email="",',
-                                '\n\tdescription="",',
-                                '\n\tlong_description=long_description,',
-                                '\n\tlong_description_content_type="text/markdown",',
-                                '\n\tclassifiers=[\n\t\t"Programming Language :: Python :: 3",'
-                                '\n\t\t"License :: OSI Approved :: MIT License"],',
-                                '\n\tpackages=find_packages(),',
-                                '\n\tinstall_requires=install_requires,',
-                                f'\n\tentry_points="""\n\t\t[archivy.plugins]'
-                                f'\n\t\t{name}=archivy_{name}:{name}""",\n)'])
+        with open(f"{name}/setup.py", "w") as setup_f:
+            setup_f.writelines(
+                [
+                    "from setuptools import setup, find_packages",
+                    '\n\nwith open("README.md", "r") as fh:',
+                    "\n\tlong_description = fh.read()",
+                    '\n\nwith open("requirements.txt", encoding="utf-8") as f:',
+                    '\n\tall_reqs = f.read().split("\\n")',
+                    "\n\tinstall_requires = [x.strip() for x in all_reqs]",
+                    "\n\n#Fill in the details below for distribution purposes"
+                    f'\nsetup(\n\tname="{name}",',
+                    '\n\tversion="0.0.1",',
+                    '\n\tauthor="",',
+                    '\n\tauthor_email="",',
+                    '\n\tdescription="",',
+                    "\n\tlong_description=long_description,",
+                    '\n\tlong_description_content_type="text/markdown",',
+                    '\n\tclassifiers=["Programming Language :: Python :: 3"],'
+                    "\n\tpackages=find_packages(),",
+                    "\n\tinstall_requires=install_requires,",
+                    f'\n\tentry_points="""\n\t\t[archivy.plugins]'
+                    f'\n\t\t{raw_name}={name}:{raw_name}"""\n)',
+                ]
+            )
 
         # Creating a basic __init__.py file where the main function of the plugin goes
-        with open(f"archivy_{name}/archivy_{name}/__init__.py", "w") as fp:
-            fp.writelines(['import archivy',
-                           '\nimport click',
-                           '\nimport requests',
-                           '\nimport tinydb',
-                           '\n\n# Fill in the functionality for the commands (Check plugins.md in archivy repository)',
-                           '\n@click.group()',
-                           f'\ndef {name}:',
-                           '\n\tpass',
-                           f'\n\n@{name}.command()',
-                           '\ndef command1():',
-                           '\n\tpass',
-                           f'\n\n@{name}.command()',
-                           '\ndef command2():',
-                           '\n\tpass'])
+        with open(f"{name}/{name}/__init__.py", "w") as fp:
+            fp.writelines(
+                [
+                    "import archivy",
+                    "\nimport click",
+                    "\n\n# Fill in the functionality for the commands (see https://archivy.github.io/plugins/)",
+                    "\n@click.group()",
+                    f"\ndef {raw_name}():",
+                    "\n\tpass",
+                    f"\n\n@{raw_name}.command()",
+                    "\ndef command1():",
+                    "\n\tpass",
+                    f"\n\n@{raw_name}.command()",
+                    "\ndef command2():",
+                    "\n\tpass",
+                ]
+            )
 
         return True
     except FileExistsError:

--- a/archivy/helpers.py
+++ b/archivy/helpers.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import sys
+import os
 
 import elasticsearch
 import yaml
@@ -157,3 +158,73 @@ def get_elastic_client(error_if_invalid=True):
         except elasticsearch.exceptions.ConnectionError:
             return False
     return es
+
+
+def create_directory(name):
+    """Creates a directory structure where one can make plugins
+
+    Args:
+        name: Name of the plugin.
+
+    Returns:
+        bool: True if successfully created else False
+
+    """
+    try:
+        os.makedirs(f"archivy_{name}/archivy_{name}")
+
+        # Creates requirements.txt.
+        with open(f"archivy_{name}/requirements.txt", "w") as fp:
+            fp.writelines(["archivy", "\ntinydb", "\nclick", "\nrequests"])
+
+        # Creates an empty readme file to be filled
+        with open(f"archivy_{name}/README.md", "w+") as fp:
+            fp.writelines(['<!-- Plugin Description -->',
+                           '\n\n## Install',
+                           '\n\nYou need to have `archivy` already installed.',
+                           f'\n\nRun `pip install archivy_{name}`',
+                           '\n\n## Usage'])
+
+        # Creates a setup.py file
+        with open(f"archivy_{name}/setup.py", "w") as setup_f:
+            setup_f.writelines(["from setuptools import setup, find_packages",
+                                '\n\nwith open("README.md", "r") as fh:',
+                                '\n\tlong_description = fh.read()',
+                                '\n\nwith open("requirements.txt", encoding="utf-8") as f:',
+                                '\n\tall_reqs = f.read().split("\\n")',
+                                '\n\tinstall_requires = [x.strip() for x in all_reqs]',
+                                '\n\n#Fill in the details below for distribution purposes'
+                                f'\nsetup(\n\tname="archivy_{name}",',
+                                '\n\tversion="0.0.1",',
+                                '\n\tauthor="",',
+                                '\n\tauthor_email="",',
+                                '\n\tdescription="",',
+                                '\n\tlong_description=long_description,',
+                                '\n\tlong_description_content_type="text/markdown",',
+                                '\n\tclassifiers=[\n\t\t"Programming Language :: Python :: 3",'
+                                '\n\t\t"License :: OSI Approved :: MIT License"],',
+                                '\n\tpackages=find_packages(),',
+                                '\n\tinstall_requires=install_requires,',
+                                f'\n\tentry_points="""\n\t\t[archivy.plugins]'
+                                f'\n\t\t{name}=archivy_{name}:{name}""",\n)'])
+
+        # Creating a basic __init__.py file where the main function of the plugin goes
+        with open(f"archivy_{name}/archivy_{name}/__init__.py", "w") as fp:
+            fp.writelines(['import archivy',
+                           '\nimport click',
+                           '\nimport requests',
+                           '\nimport tinydb',
+                           '\n\n# Fill in the functionality for the commands (Check plugins.md in archivy repository)',
+                           '\n@click.group()',
+                           f'\ndef {name}:',
+                           '\n\tpass',
+                           f'\n\n@{name}.command()',
+                           '\ndef command1():',
+                           '\n\tpass',
+                           f'\n\n@{name}.command()',
+                           '\ndef command2():',
+                           '\n\tpass'])
+
+        return True
+    except FileExistsError:
+        return False

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from tempfile import mkdtemp
 
 from tinydb import Query
@@ -238,3 +239,13 @@ def test_unformat_directory(
         f"Unformatted and moved {nested_note.fullpath} to {out_dir}/{note_dir}/{nested_note.title}"
         in res.output
     )
+
+
+def test_create_plugin_dir(test_app, cli_runner, click_cli):
+    with cli_runner.isolated_filesystem():
+        res = cli_runner.invoke(cli, ["plugin-new", "archivy_test_plugin"])
+        plugin_dir = Path("archivy_test_plugin")
+        assert plugin_dir.exists()
+        files = ["README.md", "requirements.txt", "archivy_test_plugin/__init__.py", "setup.py"]
+        for file in files:
+            assert (plugin_dir / file).exists()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -246,6 +246,11 @@ def test_create_plugin_dir(test_app, cli_runner, click_cli):
         res = cli_runner.invoke(cli, ["plugin-new", "archivy_test_plugin"])
         plugin_dir = Path("archivy_test_plugin")
         assert plugin_dir.exists()
-        files = ["README.md", "requirements.txt", "archivy_test_plugin/__init__.py", "setup.py"]
+        files = [
+            "README.md",
+            "requirements.txt",
+            "archivy_test_plugin/__init__.py",
+            "setup.py",
+        ]
         for file in files:
             assert (plugin_dir / file).exists()


### PR DESCRIPTION
Using the `archivy plugin-new <name>` can now set up a directory structure making it easier to create a plugin for archivy.
Implements #152  