### PR TITLE
WIP: feat: add ARCHIVY_INTERNAL_DIR_PATH env variable

### DIFF
--- a/archivy/config.py
+++ b/archivy/config.py
@@ -9,7 +9,10 @@ class Config(object):
         self.SECRET_KEY = os.urandom(32)
         self.PORT = 5000
         self.HOST = "127.0.0.1"
-        self.INTERNAL_DIR = appdirs.user_data_dir("archivy")
+
+        overridden_internal_dir = os.environ.get("ARCHIVY_INTERNAL_DIR_PATH")
+        self.INTERNAL_DIR = overridden_internal_dir or appdirs.user_data_dir("archivy")
+
         self.USER_DIR = self.INTERNAL_DIR
         self.DEFAULT_BOOKMARKS_DIR = ""
         self.SITE_TITLE = "Archivy"


### PR DESCRIPTION
Allows overriding default internal dir, instead of
the path chosen by appdirs

Example:


```
(venv) clemux@charlotte:~/dev/archivy$ ARCHIVY_INTERNAL_DIR_PATH=/tmp/ archivy init
This is the archivy installation initialization wizard.
Enter the full path of the directory where you'd like us to store data. [/home/clemux/dev/archivy]: /tmp/archivy
Would you like to enable search on your knowledge base contents? [y/N]: n
Would you like to create a new admin user? [y/N]: n
Host [localhost (127.0.0.1)]: 
Config successfully created at /tmp/config.yml
```