### PR TITLE
implement /api/raw_bookmark to upload bookmarks with direct html

### DIFF
--- a/archivy/api.py
+++ b/archivy/api.py
@@ -243,3 +243,21 @@ def image_upload():
         saved_to = data.save_image(image)
         return jsonify({"data": {"filePath": f"/images/{saved_to}"}}), 200
     return jsonify({"error": "415"}), 415
+
+
+@api_bp.route("/raw_bookmark", methods=["POST"])
+def raw_bookmark():
+    """
+    Creates a new bookmark from raw HTML.
+
+    Parameter in JSON body:
+    - **url**: url of new boomark
+    - **html**
+    """
+
+    bookmark = DataObj(url=request.json.get("url"), type="bookmark")
+    bookmark.process_bookmark_url(request.json.get("html"))
+    if bookmark.insert():
+        return jsonify({"status": "success", "id": bookmark.id})
+    else:
+        return jsonify({"status": "failure"}), 400

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -5,7 +5,7 @@ import responses
 from flask import Flask
 from flask.testing import FlaskClient
 from tinydb import Query
-from archivy.data import create_dir, get_items, create_dir
+from archivy.data import create_dir, get_items, create_dir, get_item
 from archivy.models import DataObj
 from archivy.helpers import get_db
 
@@ -258,3 +258,14 @@ def test_adding_invalid_tag_name_fails(test_app, client):
         resp = client.put("/api/tags/add_to_index", json={"tag": tag})
         assert b"Must provide valid tag name" in resp.data
         assert resp.status_code == 401
+
+
+def test_uploading_raw_boomark(test_app, client):
+    json = {
+        "url": "https://example.com",
+        "html": "<html><head><title>Example website</title></head><body><h1>Example bookmark uploaded raw</h1></body></html>",
+    }
+    resp = client.post("/api/raw_bookmark", json=json)
+    assert resp.status_code == 200
+    id = resp.json["id"]
+    assert get_item(id)


### PR DESCRIPTION
@clemux mentioned how for paywalled content / a potential bookmarklet, it's useful to be able to directly upload a bookmark from raw HTML.

We could use this in the bookmarklet to directly upload the current page instead of fetching the bookmark URL.