### PR TITLE
Autosave / better highlighting of when things aren't saved

### DIFF
--- a/archivy/config.py
+++ b/archivy/config.py
@@ -28,6 +28,7 @@ class Config(object):
         }
         self.DATAOBJ_JS_EXTENSION = ""
         self.EDITOR_CONF = {
+            "autosave": True,
             "settings": {
                 "html": False,
                 "xhtmlOut": False,

--- a/archivy/routes.py
+++ b/archivy/routes.py
@@ -35,7 +35,7 @@ def pass_defaults():
     # check windows parsing for js (https://github.com/Uzay-G/archivy/issues/115)
     if SEP == "\\":
         SEP += "\\"
-    return dict(dataobjs=dataobjs, SEP=SEP, version=version)
+    return dict(dataobjs=dataobjs, SEP=SEP, version=version, config=app.config)
 
 
 @app.before_request
@@ -69,8 +69,7 @@ def index():
         new_folder_form=forms.NewFolderForm(),
         delete_form=forms.DeleteFolderForm(),
         rename_form=forms.RenameDirectoryForm(),
-        view_only=0,
-        search_engine=app.config["SEARCH_CONF"]["engine"],
+        view_only=0
     )
 
 

--- a/archivy/templates/dataobjs/show.html
+++ b/archivy/templates/dataobjs/show.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+
+{% set search_enabled = config['SEARCH_CONF']['enabled'] %}
 {% block content %}
   <form id="tag_tooltip" class="hidden">
     <input list="tags" id="tag_tooltip_input" class="floating_input" required />
@@ -186,7 +188,7 @@
           imageAccept: "image/png, image/jpeg, image/gif",
           imageMaxSize: "100000000",
           toolbar: [
-            {% for icon in icons %}
+            {% for icon in config['EDITOR_CONF']['toolbar_icons'] %}
               "{{ icon }}",
             {% endfor %}
             {
@@ -237,19 +239,19 @@
               }, // action
             }, // save-button
             {
-              name: "status",
-              className: "fa fa-check-circle status"
-            },
-            {
               name: "doc",
               className: "fa fa-question-circle",
               action: "https://archivy.github.io/editing",
               title: "Editing Guide"
-            }
+            },
+            {
+              name: "status",
+              className: "fa fa-check-circle status"
+            },
           ], // toolbar
           shortcuts: {
             "save": "Ctrl-S"
-          },
+          }
         });  // EasyMDE
 
         editor.value(content)
@@ -260,9 +262,11 @@
         {% endif %}
 
         let statusBtn = document.querySelector(".status .fa");
+        statusBtn.style.color = "green";
         editor.codemirror.on("change", function() {
           statusBtn.classList.remove("fa-check-circle");
           statusBtn.classList.add("fa-times")
+          statusBtn.style.color = "red";
         })
         oldContent = document.getElementById("content"), editorDiv = document.querySelector(".EasyMDEContainer");
         editorDiv.classList.add("hidden");
@@ -315,6 +319,7 @@
           response = fetch(`${SCRIPT_ROOT}/tags/add_to_index`, payload);
         }
 
+        let timeoutId;
         async function saveDoc() {
           let req;
           try {
@@ -335,6 +340,7 @@
           if (!req.ok) { alert("Error saving document."); }
           statusBtn.classList.add("fa-check-circle");
           statusBtn.classList.remove("fa-times");
+          statusBtn.style.color = "green";
           savedContent = editor.value();
           // update dataobj tags
           let post_tags = document.querySelector(".embedded-tags");
@@ -389,6 +395,13 @@
         //   Check what the last character is. Is it a `#`?
         //   Then get rid of the `#` and put it into the tag tooltip and show that.
         editor.codemirror.on("change", function(ed, change) {
+          // auto save functionality
+          {% if config["EDITOR_CONF"]['autosave'] %}
+            if (!timeoutId)
+            {
+              timeoutId = setTimeout(() => {saveDoc(); timeoutId = null;}, 2500);
+            }
+          {% endif %}
           let line = ed.doc.getCursor().line, // Cursor line
           ch = ed.doc.getCursor().ch;
           let currLine = ed.doc.getLine(line);

--- a/archivy/templates/home.html
+++ b/archivy/templates/home.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 
+{% set search_enabled = config['SEARCH_CONF']['enabled'] %}
 {% if search_enabled %}
     <input type="text" id="searchBar" placeholder="Search">
     <ul id="searchHits"></ul>


### PR DESCRIPTION
@ZeroDawn0D brought it to my attention that the UX for signaling when content isn't saved, isn't complete enough. I think autosave / coloring in green / red the status icon when things aren't saved is a good step in this direction:

![random](https://user-images.githubusercontent.com/52892257/164536755-0eaf1dbe-bd09-44f8-add2-c4c9d00bafa8.gif)

What do you think of this sort of change? @edditler i'd also be interested in what you think.

For now I did so it saves 2.5 changes after you edit, not sure if that's too little or not. I'll probably also make it so that you can enable this in the editor on top of the general archivy config.